### PR TITLE
chore: enforce nonRoot for daps certs

### DIFF
--- a/charts/umbrella/charts/certs/templates/job-daps.yaml
+++ b/charts/umbrella/charts/certs/templates/job-daps.yaml
@@ -24,6 +24,11 @@ metadata:
 spec:
   template:
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsGroup: 101
+        runAsUser: 100
+        fsGroup: 101
       containers:
       - name: transfer
         image: ghcr.io/taskmedia/curl-jq:main


### PR DESCRIPTION
## Description

The job for registering the certificates on the daps should run as nonRoot job.

### Additional information

- related to #28 - will decrease kyverno nonRoot findings

<hr />

Marco Lecheler [marco.lecheler@mercedes-benz.com](mailto:marco.lecheler@mercedes-benz.com) Mercedes-Benz Tech Innovation GmbH ([ProviderInformation](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md))