### PR TITLE
feat: add config to portal, iam and discoveryfinder and update docs

### DIFF
--- a/charts/umbrella/Chart.yaml
+++ b/charts/umbrella/Chart.yaml
@@ -28,7 +28,7 @@ sources:
   - https://github.com/eclipse-tractusx/e2e-testing
 
 type: application
-version: 0.8.0
+version: 0.9.0
 
 dependencies:
 #  # TODO: update edc components to R23.12

--- a/charts/umbrella/Chart.yaml
+++ b/charts/umbrella/Chart.yaml
@@ -20,12 +20,12 @@
 apiVersion: v2
 name: umbrella
 description: |
-  A Helm chart to spin up Catena-X OSS components to simulate a complete dataspace network.
+  A Helm chart to spin up Tractus-X OSS components to simulate a complete dataspace network.
 
-  With this Helm chart you are able to create a sandbox environment or run end-to-end.
+  With this Helm chart you are able to run end-to-end or create a sandbox environment.
 
 sources:
-  - https://github.com/eclipse-tractusx/e2e-testing
+  - https://github.com/eclipse-tractusx/tractus-x-umbrella
 
 type: application
 version: 0.9.0

--- a/charts/umbrella/README.md
+++ b/charts/umbrella/README.md
@@ -1,15 +1,15 @@
-# E2E umbrella Chart
+# Umbrella Chart
 
-This e2e umbrella Chart is a basis for end-to-end testing of an [Catena-X](https://catena-x.net/en/) automotive dataspace network
-consisting of [Tractus-X](https://projects.eclipse.org/projects/automotive.tractusx) OSS coponents.
+This umbrella chart provides a basis for running end-to-end tests or creating a sandbox environment of the [Catena-X](https://catena-x.net/en/) automotive dataspace network
+consisting of [Tractus-X](https://projects.eclipse.org/projects/automotive.tractusx) OSS components.
 
-The Chart aims for a completely automated setup of a fully functional network, that does not require manual setup steps.
+The chart aims for a completely automated setup of a fully functional network, that does not require manual setup steps.
 
 ## Installing
 
 Running this Chart requires a kubernetes cluster `>1.24.x`. One of the options is to run a local instance of [minikube](https://minikube.sigs.k8s.io/docs/start/) setup.
 Assuming you have a running cluster and your `kubectl` context is set to that cluster, you can use the following command to install
-the Chart as `lab` release.
+the chart as `umbrella` release.
 
 ### (Optional) Self-signed TLS setup
 
@@ -89,7 +89,7 @@ helm install umbrella . --namespace umbrella --create-namespace
 
 ## Uninstalling
 
-To taredown your setup, run:
+To teardown your setup, run:
 
 ```shell
 helm delete umbrella --namespace umbrella

--- a/charts/umbrella/README.md
+++ b/charts/umbrella/README.md
@@ -11,19 +11,88 @@ Running this Chart requires a kubernetes cluster `>1.24.x`. One of the options i
 Assuming you have a running cluster and your `kubectl` context is set to that cluster, you can use the following command to install
 the Chart as `lab` release.
 
+### (Optional) Self-signed TLS setup
+
+Install cert-manager chart in the same namespace where the umbrella chart will be located.
+
+```bash
+helm repo add jetstack https://charts.jetstack.io
+helm repo update
+```
+
+```bash
+helm install \
+  cert-manager jetstack/cert-manager \
+  --namespace umbrella \
+  --create-namespace \
+  --version v1.14.4 \
+  --set installCRDs=true
+```
+
+Configure the self-signed certificate and issuer to be used by the ingress resources.
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: selfsigned-issuer
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: my-selfsigned-ca
+  namespace: umbrella
+spec:
+  isCA: true
+  commonName: cx.local
+  secretName: root-secret
+  privateKey:
+    algorithm: RSA
+    size: 2048
+  issuerRef:
+    name: selfsigned-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io
+  subject:
+    organizations:
+      - CX
+    countries:
+      - DE
+    provinces:
+      - Some-State
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: my-ca-issuer
+spec:
+  ca:
+    secretName: root-secret
+EOF
+```
+
+See [cert-manager self-signed](https://cert-manager.io/docs/configuration/selfsigned) for reference.
+
+### Installing the chart
+
 ```shell
 # Download (recursive chart dependencies) with hack script
 hack/helm-dependencies.bash
 
 cd charts/umbrella
 
-helm install lab . --namespace lab --create-namespace
+helm install umbrella . --namespace umbrella --create-namespace
 ```
+
+## Uninstalling
 
 To taredown your setup, run:
 
 ```shell
-helm delete lab --namespace lab
+helm delete umbrella --namespace umbrella
 ```
 
 ## How to contribute

--- a/charts/umbrella/templates/centralidp-spi.yaml
+++ b/charts/umbrella/templates/centralidp-spi.yaml
@@ -1,5 +1,5 @@
 {{- /*
-* Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/charts/umbrella/templates/centralidp-spi.yaml
+++ b/charts/umbrella/templates/centralidp-spi.yaml
@@ -1,0 +1,40 @@
+{{- /*
+* Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+*
+* See the NOTICE file(s) distributed with this work for additional
+* information regarding copyright ownership.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Apache License, Version 2.0 which is available at
+* https://www.apache.org/licenses/LICENSE-2.0.
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations
+* under the License.
+*
+* SPDX-License-Identifier: Apache-2.0
+*/}}
+
+{{- if .Values.centralidp.enabled -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: centralidp-spi
+  namespace: {{ .Release.Namespace }}
+type: Opaque
+# use lookup function to check if secret exists
+{{- $secret := (lookup "v1" "Secret" .Release.Namespace "centralidp-spi") }}
+{{ if $secret -}}
+data:
+  # if secret exists, use value provided from values file (to cover update scenario) or existing value from secret
+  # use data map instead of stringData to prevent base64 encoding of already base64-encoded existing value from secret
+  # use index function for secret keys with hyphen otherwise '$secret.data.secretKey' works too
+  spi-truststore-password: {{ ( .Values.centralidp.secrets.auth.spi.truststorePassword | b64enc ) | default ( index $secret.data "spi-truststore-password" ) | quote }}
+{{ else -}}
+stringData:
+  # if secret doesn't exist, use provided value from values file or generate a random one
+  spi-truststore-password: {{ ( .Values.centralidp.secrets.auth.spi.truststorePassword | b64enc ) | default ( randAlphaNum 32 | quote ) }}
+{{ end }}
+{{- end -}}

--- a/charts/umbrella/templates/sharedidp-spi.yaml
+++ b/charts/umbrella/templates/sharedidp-spi.yaml
@@ -1,0 +1,40 @@
+{{- /*
+* Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+*
+* See the NOTICE file(s) distributed with this work for additional
+* information regarding copyright ownership.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Apache License, Version 2.0 which is available at
+* https://www.apache.org/licenses/LICENSE-2.0.
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations
+* under the License.
+*
+* SPDX-License-Identifier: Apache-2.0
+*/}}
+
+{{- if .Values.sharedidp.enabled -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sharedidp-spi
+  namespace: {{ .Release.Namespace }}
+type: Opaque
+# use lookup function to check if secret exists
+{{- $secret := (lookup "v1" "Secret" .Release.Namespace "sharedidp-spi") }}
+{{ if $secret -}}
+data:
+  # if secret exists, use value provided from values file (to cover update scenario) or existing value from secret
+  # use data map instead of stringData to prevent base64 encoding of already base64-encoded existing value from secret
+  # use index function for secret keys with hyphen otherwise '$secret.data.secretKey' works too
+  spi-truststore-password: {{ ( .Values.sharedidp.secrets.auth.spi.truststorePassword | b64enc ) | default ( index $secret.data "spi-truststore-password" ) | quote }}
+{{ else -}}
+stringData:
+  # if secret doesn't exist, use provided value from values file or generate a random one
+  spi-truststore-password: {{ ( .Values.sharedidp.secrets.auth.spi.truststorePassword | b64enc ) | default ( randAlphaNum 32 | quote ) }}
+{{ end }}
+{{- end -}}

--- a/charts/umbrella/templates/sharedidp-spi.yaml
+++ b/charts/umbrella/templates/sharedidp-spi.yaml
@@ -1,5 +1,5 @@
 {{- /*
-* Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+* Copyright (c) 2024 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.

--- a/charts/umbrella/values.yaml
+++ b/charts/umbrella/values.yaml
@@ -144,6 +144,90 @@ portal:
     postgresql:
     nameOverride: "portal-backend-postgresql"
     architecture: standalone
+  portalAddress: "https://portal.example.org"
+  portalBackendAddress: "https://portal-backend.example.org"
+  frontend:
+    ingress:
+      enabled: true
+      annotations:
+        cert-manager.io/cluster-issuer: "my-ca-issuer"
+        nginx.ingress.kubernetes.io/rewrite-target: "/$1"
+        nginx.ingress.kubernetes.io/use-regex: "true"
+        nginx.ingress.kubernetes.io/enable-cors: "true"
+        nginx.ingress.kubernetes.io/cors-allow-origin: "https://*.example.org"
+      tls:
+        # -- Provide tls secret.
+        - secretName: "portal.example.org-tls"
+          # -- Provide host for tls secret.
+          hosts:
+            - "portal.example.org"
+      hosts:
+        - host: "portal.example.org"
+          paths:
+            - path: "/(.*)"
+              pathType: "ImplementationSpecific"
+              backend:
+                service: "portal"
+                port: 8080
+            - path: "/registration/(.*)"
+              pathType: "ImplementationSpecific"
+              backend:
+                service: "registration"
+                port: 8080
+            - path: "/((assets|documentation)/.*)"
+              pathType: "ImplementationSpecific"
+              backend:
+                service: "assets"
+                port: 8080
+  backend:
+    ingress:
+      enabled: true
+      name: "portal-backend"
+      annotations:
+        cert-manager.io/cluster-issuer: "my-ca-issuer"
+        nginx.ingress.kubernetes.io/use-regex: "true"
+        nginx.ingress.kubernetes.io/enable-cors: "true"
+        nginx.ingress.kubernetes.io/proxy-body-size: "8m"
+        nginx.ingress.kubernetes.io/cors-allow-origin: "http://localhost:3000, https://*.example.org"
+      tls:
+        # -- Provide tls secret.
+        - secretName: "portal-backend.example.org-tls"
+          # -- Provide host for tls secret.
+          hosts:
+            - "portal-backend.example.org"
+      hosts:
+        - host: "portal-backend.example.org"
+          paths:
+            - path: "/api/registration"
+              pathType: "Prefix"
+              backend:
+                service: "registration-service"
+                port: 8080
+            - path: "/api/administration"
+              pathType: "Prefix"
+              backend:
+                service: "administration-service"
+                port: 8080
+            - path: "/api/notification"
+              pathType: "Prefix"
+              backend:
+                service: "notification-service"
+                port: 8080
+            - path: "/api/provisioning"
+              pathType: "Prefix"
+              backend:
+                service: "provisioning-service"
+                port: 8080
+            - path: "/api/apps"
+              pathType: "Prefix"
+              backend:
+                service: "marketplace-app-service"
+                port: 8080
+            - path: "/api/services"
+              pathType: "Prefix"
+              backend:
+                service: "services-service"
+                port: 8080
 
 centralidp:
   enabled: true
@@ -167,6 +251,84 @@ centralidp:
     postgresql:
       nameOverride: "centralidp-postgresql"
       architecture: standalone
+    proxy: edge
+    extraEnvVars:
+      - name: KEYCLOAK_LOG_LEVEL
+        value: TRACE
+      - name: KEYCLOAK_SPI_TRUSTSTORE_FILE
+        value: "/opt/bitnami/keycloak/certs/keycloak.truststore.jks"
+      - name: "JAVA_OPTS"
+        value: "-Djavax.net.debug=ssl -Djavax.net.ssl.trustStore=$KEYCLOAK_SPI_TRUSTSTORE_PASSWORD -Djavax.net.ssl.trustStorePassword=$KEYCLOAK_SPI_TRUSTSTORE_PASSWORD"
+      - name: KEYCLOAK_SPI_TRUSTSTORE_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: centralidp-spi
+            key: spi-truststore-password
+    extraVolumes:
+      - name: certificates
+        secret:
+          secretName: root-secret
+          defaultMode: 420
+      - name: shared-certs
+        emptyDir: {}
+      - name: themes
+        emptyDir: {}
+      - name: realms
+        emptyDir: {}
+    extraVolumeMounts:
+      - name: certificates
+        mountPath: /certs
+      - name: shared-certs
+        mountPath: "/opt/bitnami/keycloak/certs"
+      - name: themes
+        mountPath: "/opt/bitnami/keycloak/themes/catenax-central"
+      - name: realms
+        mountPath: "/realms"
+    initContainers:
+      - name: init-certs
+        image: docker.io/bitnami/keycloak:22.0.3-debian-11-r14
+        imagePullPolicy: Always
+        command: ["/bin/bash"]
+        args:
+          - -ec
+          - |-
+            keytool -import -file "/certs/tls.crt" \
+                    -keystore "/opt/bitnami/keycloak/certs/keycloak.truststore.jks" \
+                    -storepass "${KEYCLOAK_SPI_TRUSTSTORE_PASSWORD}" \
+                    -noprompt
+        env:
+          - name: KEYCLOAK_SPI_TRUSTSTORE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: centralidp-spi
+                key: spi-truststore-password
+        volumeMounts:
+          - name: certificates
+            mountPath: /certs
+          - name: shared-certs
+            mountPath: "/opt/bitnami/keycloak/certs"
+    ingress:
+      enabled: true
+      ingressClassName: "nginx"
+      hostname: "centralidp.example.org"
+      annotations:
+        cert-manager.io/cluster-issuer: "my-ca-issuer"
+        nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
+        nginx.ingress.kubernetes.io/cors-allow-methods: "PUT, GET, POST, OPTIONS"
+        nginx.ingress.kubernetes.io/cors-allow-origin: "https://centralidp.example.org"
+        nginx.ingress.kubernetes.io/enable-cors: "true"
+        nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+        nginx.ingress.kubernetes.io/proxy-buffering: "on"
+        nginx.ingress.kubernetes.io/proxy-buffers-number: "20"
+        nginx.ingress.kubernetes.io/use-regex: "true"
+      tls: true
+  secrets:
+    auth:
+      existingSecret:
+        # -- Password for the admin username 'admin'. Secret-key 'admin-password'.
+        adminpassword: ""
+      spi:
+        truststorePassword: ""
 
 sharedidp:
   enabled: true
@@ -190,6 +352,74 @@ sharedidp:
     postgresql:
       nameOverride: "sharedidp-postgresql"
       architecture: standalone
+    proxy: edge
+    extraEnvVars:
+      - name: KEYCLOAK_SPI_TRUSTSTORE_FILE
+        value: "/opt/bitnami/keycloak/certs/keycloak.truststore.jks"
+      - name: "JAVA_OPTS"
+        value: "-Djavax.net.debug=ssl -Djavax.net.ssl.trustStore=$KEYCLOAK_SPI_TRUSTSTORE_PASSWORD -Djavax.net.ssl.trustStorePassword=$KEYCLOAK_SPI_TRUSTSTORE_PASSWORD"
+      - name: KEYCLOAK_SPI_TRUSTSTORE_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: sharedidp-spi
+            key: spi-truststore-password
+    extraVolumes:
+      - name: certificates
+        secret:
+          secretName: root-secret
+          defaultMode: 420
+      - name: shared-certs
+        emptyDir: {}
+    extraVolumeMounts:
+      - name: certificates
+        mountPath: /certs
+      - name: shared-certs
+        mountPath: "/opt/bitnami/keycloak/certs"
+    initContainers:
+      - name: init-certs
+        image: docker.io/bitnami/keycloak:22.0.3-debian-11-r14
+        imagePullPolicy: Always
+        command: ["/bin/bash"]
+        args:
+          - -ec
+          - |-
+            keytool -import -file "/certs/tls.crt" \
+                    -keystore "/opt/bitnami/keycloak/certs/keycloak.truststore.jks" \
+                    -storepass "${KEYCLOAK_SPI_TRUSTSTORE_PASSWORD}" \
+                    -noprompt
+        env:
+          - name: KEYCLOAK_SPI_TRUSTSTORE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: sharedidp-spi
+                key: spi-truststore-password
+        volumeMounts:
+          - name: certificates
+            mountPath: /certs
+          - name: shared-certs
+            mountPath: "/opt/bitnami/keycloak/certs"
+    ingress:
+      enabled: true
+      ingressClassName: "nginx"
+      hostname: "sharedidp.example.org"
+      annotations:
+        cert-manager.io/cluster-issuer: "my-ca-issuer"
+        nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
+        nginx.ingress.kubernetes.io/cors-allow-methods: "PUT, GET, POST, OPTIONS"
+        nginx.ingress.kubernetes.io/cors-allow-origin: "https://sharedidp.example.org"
+        nginx.ingress.kubernetes.io/enable-cors: "true"
+        nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+        nginx.ingress.kubernetes.io/proxy-buffering: "on"
+        nginx.ingress.kubernetes.io/proxy-buffers-number: "20"
+        nginx.ingress.kubernetes.io/use-regex: "true"
+      tls: true
+  secrets:
+    auth:
+      existingSecret:
+        # -- Password for the admin username 'admin'. Secret-key 'admin-password'.
+        adminpassword: ""
+      spi:
+        truststorePassword: ""
 
 bpndiscovery:
   enabled: true

--- a/charts/umbrella/values.yaml
+++ b/charts/umbrella/values.yaml
@@ -234,6 +234,10 @@ centralidp:
   keycloak:
     nameOverride: "centralidp"
     replicaCount: 1
+    postgresql:
+      nameOverride: "centralidp-postgresql"
+      architecture: standalone
+    proxy: edge
     initContainers:
       - name: import
         image: docker.io/tractusx/umbrella-init-container:0.0.1-init
@@ -248,43 +252,6 @@ centralidp:
         volumeMounts:
         - name: realms
           mountPath: "/realms"
-    postgresql:
-      nameOverride: "centralidp-postgresql"
-      architecture: standalone
-    proxy: edge
-    extraEnvVars:
-      - name: KEYCLOAK_LOG_LEVEL
-        value: TRACE
-      - name: KEYCLOAK_SPI_TRUSTSTORE_FILE
-        value: "/opt/bitnami/keycloak/certs/keycloak.truststore.jks"
-      - name: "JAVA_OPTS"
-        value: "-Djavax.net.debug=ssl -Djavax.net.ssl.trustStore=$KEYCLOAK_SPI_TRUSTSTORE_PASSWORD -Djavax.net.ssl.trustStorePassword=$KEYCLOAK_SPI_TRUSTSTORE_PASSWORD"
-      - name: KEYCLOAK_SPI_TRUSTSTORE_PASSWORD
-        valueFrom:
-          secretKeyRef:
-            name: centralidp-spi
-            key: spi-truststore-password
-    extraVolumes:
-      - name: certificates
-        secret:
-          secretName: root-secret
-          defaultMode: 420
-      - name: shared-certs
-        emptyDir: {}
-      - name: themes
-        emptyDir: {}
-      - name: realms
-        emptyDir: {}
-    extraVolumeMounts:
-      - name: certificates
-        mountPath: /certs
-      - name: shared-certs
-        mountPath: "/opt/bitnami/keycloak/certs"
-      - name: themes
-        mountPath: "/opt/bitnami/keycloak/themes/catenax-central"
-      - name: realms
-        mountPath: "/realms"
-    initContainers:
       - name: init-certs
         image: docker.io/bitnami/keycloak:22.0.3-debian-11-r14
         imagePullPolicy: Always
@@ -307,6 +274,34 @@ centralidp:
             mountPath: /certs
           - name: shared-certs
             mountPath: "/opt/bitnami/keycloak/certs"
+    extraEnvVars:
+      - name: KEYCLOAK_LOG_LEVEL
+        value: TRACE
+      - name: KEYCLOAK_SPI_TRUSTSTORE_FILE
+        value: "/opt/bitnami/keycloak/certs/keycloak.truststore.jks"
+      - name: KEYCLOAK_SPI_TRUSTSTORE_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: centralidp-spi
+            key: spi-truststore-password
+      - name: KEYCLOAK_EXTRA_ARGS
+        value: "-Dkeycloak.migration.action=import -Dkeycloak.migration.provider=singleFile -Dkeycloak.migration.file=/realms/CX-Central-realm.json -Dkeycloak.migration.strategy=IGNORE_EXISTING"
+    extraVolumes:
+      - name: realms
+        emptyDir: {}
+      - name: certificates
+        secret:
+          secretName: root-secret
+          defaultMode: 420
+      - name: shared-certs
+        emptyDir: {}
+    extraVolumeMounts:
+      - name: realms
+        mountPath: "/realms"
+      - name: certificates
+        mountPath: /certs
+      - name: shared-certs
+        mountPath: "/opt/bitnami/keycloak/certs"
     ingress:
       enabled: true
       ingressClassName: "nginx"
@@ -335,6 +330,10 @@ sharedidp:
   keycloak:
     nameOverride: "sharedidp"
     replicaCount: 1
+    postgresql:
+      nameOverride: "sharedidp-postgresql"
+      architecture: standalone
+    proxy: edge
     initContainers:
       - name: import
         image: docker.io/tractusx/umbrella-init-container:0.0.1-init
@@ -349,33 +348,6 @@ sharedidp:
         volumeMounts:
         - name: realms
           mountPath: "/realms"
-    postgresql:
-      nameOverride: "sharedidp-postgresql"
-      architecture: standalone
-    proxy: edge
-    extraEnvVars:
-      - name: KEYCLOAK_SPI_TRUSTSTORE_FILE
-        value: "/opt/bitnami/keycloak/certs/keycloak.truststore.jks"
-      - name: "JAVA_OPTS"
-        value: "-Djavax.net.debug=ssl -Djavax.net.ssl.trustStore=$KEYCLOAK_SPI_TRUSTSTORE_PASSWORD -Djavax.net.ssl.trustStorePassword=$KEYCLOAK_SPI_TRUSTSTORE_PASSWORD"
-      - name: KEYCLOAK_SPI_TRUSTSTORE_PASSWORD
-        valueFrom:
-          secretKeyRef:
-            name: sharedidp-spi
-            key: spi-truststore-password
-    extraVolumes:
-      - name: certificates
-        secret:
-          secretName: root-secret
-          defaultMode: 420
-      - name: shared-certs
-        emptyDir: {}
-    extraVolumeMounts:
-      - name: certificates
-        mountPath: /certs
-      - name: shared-certs
-        mountPath: "/opt/bitnami/keycloak/certs"
-    initContainers:
       - name: init-certs
         image: docker.io/bitnami/keycloak:22.0.3-debian-11-r14
         imagePullPolicy: Always
@@ -398,6 +370,32 @@ sharedidp:
             mountPath: /certs
           - name: shared-certs
             mountPath: "/opt/bitnami/keycloak/certs"
+    extraEnvVars:
+      - name: KEYCLOAK_SPI_TRUSTSTORE_FILE
+        value: "/opt/bitnami/keycloak/certs/keycloak.truststore.jks"
+      - name: KEYCLOAK_SPI_TRUSTSTORE_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: sharedidp-spi
+            key: spi-truststore-password
+      - name: KEYCLOAK_EXTRA_ARGS
+        value: "-Dkeycloak.migration.action=import -Dkeycloak.migration.provider=dir -Dkeycloak.migration.dir=/realms -Dkeycloak.migration.strategy=IGNORE_EXISTING"
+    extraVolumes:
+      - name: realms
+        emptyDir: {}
+      - name: certificates
+        secret:
+          secretName: root-secret
+          defaultMode: 420
+      - name: shared-certs
+        emptyDir: {}
+    extraVolumeMounts:
+      - name: realms
+        mountPath: "/realms"
+      - name: certificates
+        mountPath: /certs
+      - name: shared-certs
+        mountPath: "/opt/bitnami/keycloak/certs"
     ingress:
       enabled: true
       ingressClassName: "nginx"

--- a/charts/umbrella/values.yaml
+++ b/charts/umbrella/values.yaml
@@ -146,6 +146,15 @@ portal:
     architecture: standalone
   portalAddress: "https://portal.example.org"
   portalBackendAddress: "https://portal-backend.example.org"
+  centralidpAddress: "https://centralidp.example.org"
+  sharedidpAddress: "https://sharedidp.example.org"
+  semanticsAddress: "https://semantics.example.org"
+  bpdmPartnersPoolAddress: "https://business-partners.example.org"
+  bpdmPortalGateAddress: "https://business-partners.example.org"
+  custodianAddress: "https://managed-identity-wallets.example.org"
+  sdfactoryAddress: "https://sdfactory.example.org"
+  clearinghouseAddress: "https://validation.example.org"
+  clearinghouseTokenAddress: "https://keycloak.example.org/realms/example/protocol/openid-connect/token"
   frontend:
     ingress:
       enabled: true
@@ -180,6 +189,41 @@ portal:
                 service: "assets"
                 port: 8080
   backend:
+    dotnetEnvironment: "Development"
+    keycloak:
+      central:
+        clientId: "sa-cl1-reg-2"
+        clientSecret: "aEoUADDw2aNPa0WAaKGAyKfC80n8sKxJ"
+        jwtBearerOptions:
+          requireHttpsMetadata: "false"
+      shared:
+        clientId: "sa-cl1-reg-1"
+        clientSecret: "YPA1t6BMQtPtaG3fpH8Sa8Ac6KYbPUM7"
+    registration:
+      swaggerEnabled: true
+    administration:
+      swaggerEnabled: true
+    appmarketplace:
+      swaggerEnabled: true
+    services:
+      swaggerEnabled: true
+    notification:
+      swaggerEnabled: true
+    mailing:
+      host: "smtp.example.org"
+      port: "587"
+      user: "smtp-user"
+      senderEmail: "smtp@example.org"
+      password: ""
+    provisioning:
+      sharedRealm:
+        smtpServer:
+          host: "smtp.example.org"
+          port: "587"
+          user: "smtp-user"
+          password: ""
+          from: "smtp@example.org"
+          replyTo: "smtp@example.org"
     ingress:
       enabled: true
       name: "portal-backend"
@@ -239,7 +283,7 @@ centralidp:
       architecture: standalone
     proxy: edge
     initContainers:
-      - name: import
+      - name: realm-import
         image: docker.io/tractusx/umbrella-init-container:0.0.1-init
         imagePullPolicy: Always
         command:
@@ -252,6 +296,19 @@ centralidp:
         volumeMounts:
         - name: realms
           mountPath: "/realms"
+      - name: theme-import
+        image: docker.io/tractusx/portal-iam:v2.1.0
+        imagePullPolicy: Always
+        command:
+          - sh
+        args:
+          - -c
+          - |
+            echo "Copying themes..."
+            cp -R /import/themes/catenax-central/* /themes
+        volumeMounts:
+        - name: themes
+          mountPath: "/themes"
       - name: init-certs
         image: docker.io/bitnami/keycloak:22.0.3-debian-11-r14
         imagePullPolicy: Always
@@ -289,6 +346,8 @@ centralidp:
     extraVolumes:
       - name: realms
         emptyDir: {}
+      - name: themes
+        emptyDir: {}
       - name: certificates
         secret:
           secretName: root-secret
@@ -298,6 +357,8 @@ centralidp:
     extraVolumeMounts:
       - name: realms
         mountPath: "/realms"
+      - name: themes
+        mountPath: "/opt/bitnami/keycloak/themes/catenax-central"
       - name: certificates
         mountPath: /certs
       - name: shared-certs
@@ -335,7 +396,7 @@ sharedidp:
       architecture: standalone
     proxy: edge
     initContainers:
-      - name: import
+      - name: realm-import
         image: docker.io/tractusx/umbrella-init-container:0.0.1-init
         imagePullPolicy: Always
         command:
@@ -348,6 +409,23 @@ sharedidp:
         volumeMounts:
         - name: realms
           mountPath: "/realms"
+      - name: theme-import
+        image: docker.io/tractusx/portal-iam:v2.1.0
+        imagePullPolicy: Always
+        command:
+          - sh
+        args:
+          - -c
+          - |
+            echo "Copying themes-catenax-shared..."
+            cp -R /import/themes/catenax-shared/* /themes-catenax-shared
+            echo "Copying themes-catenax-shared-portal..."
+            cp -R /import/themes/catenax-shared-portal/* /themes-catenax-shared-portal
+        volumeMounts:
+        - name: themes-catenax-shared
+          mountPath: "/themes-catenax-shared"
+        - name: themes-catenax-shared-portal
+          mountPath: "/themes-catenax-shared-portal"
       - name: init-certs
         image: docker.io/bitnami/keycloak:22.0.3-debian-11-r14
         imagePullPolicy: Always
@@ -383,6 +461,10 @@ sharedidp:
     extraVolumes:
       - name: realms
         emptyDir: {}
+      - name: themes-catenax-shared
+        emptyDir: {}
+      - name: themes-catenax-shared-portal
+        emptyDir: {}
       - name: certificates
         secret:
           secretName: root-secret
@@ -392,6 +474,10 @@ sharedidp:
     extraVolumeMounts:
       - name: realms
         mountPath: "/realms"
+      - name: themes-catenax-shared
+        mountPath: "/opt/bitnami/keycloak/themes/catenax-shared"
+      - name: themes-catenax-shared-portal
+        mountPath: "/opt/bitnami/keycloak/themes/catenax-shared-portal"
       - name: certificates
         mountPath: /certs
       - name: shared-certs
@@ -441,28 +527,36 @@ discoveryfinder:
   enabled: true
   enablePostgres: true
   discoveryfinder:
-    authentication: false
+    authentication: true
     livenessProbe:
       initialDelaySeconds: 200
     readinessProbe:
       initialDelaySeconds: 200
-  host: semantics.example.org
-  ## If 'authentication' is set to false, no OAuth authentication is enforced
-  authentication: false
-  properties:
-    discoveryfinder:
-      # Initial Endpoint for edc discovery with type bpn
-      initialEndpoints:
-        - type: bpn
-          endpointAddress: https://portal-backend.example.org/api/administration/Connectors/discovery
-          description: Service to discover connector endpoints based on bpns
-          documentation: https://portal-backend.example.org/api/administration/swagger/index.html
-  idp:
-    issuerUri: "https://centralidp.example.org/auth/realms/CX-Central"
-    # publicClientId: ""
-  ingress:
-    enabled: true
-    tls: true
+    host: semantics.example.org
+    properties:
+      discoveryfinder:
+        initialEndpoints:
+          - type: bpn
+            endpointAddress: https://portal-backend.example.org/api/administration/Connectors/discovery
+            description: Service to discover connector endpoints based on bpns
+            documentation: https://portal-backend.example.org/api/administration/swagger/index.html
+    idp:
+      issuerUri: "https://centralidp.example.org/auth/realms/CX-Central"
+      publicClientId: "Cl21-CX-DF"
+    dataSource:
+      url: "jdbc:postgresql://{{ .Release.Name }}-discoveryfinder-postgresql:5432/discoveryfinder"
+    ingress:
+      enabled: true
+      tls: true
+      urlPrefix: "/discoveryfinder"
+      className: "nginx"
+      annotations:
+        cert-manager.io/cluster-issuer: "my-ca-issuer"
+        nginx.ingress.kubernetes.io/rewrite-target: "/$2"
+        nginx.ingress.kubernetes.io/use-regex: "true"
+        nginx.ingress.kubernetes.io/enable-cors: "true"
+        nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
+        nginx.ingress.kubernetes.io/x-forwarded-prefix: "/discoveryfinder"
   postgresql:
     nameOverride: "discoveryfinder-postgresql"
 

--- a/charts/umbrella/values.yaml
+++ b/charts/umbrella/values.yaml
@@ -461,7 +461,7 @@ discoveryfinder:
           documentation: https://portal-backend.example.org/api/administration/swagger/index.html
   idp:
     issuerUri: "https://centralidp.example.org/auth/realms/CX-Central"
-    #publicClientId: ""
+    # publicClientId: ""
   ingress:
     enabled: true
     tls: true

--- a/charts/umbrella/values.yaml
+++ b/charts/umbrella/values.yaml
@@ -448,6 +448,23 @@ discoveryfinder:
       initialDelaySeconds: 200
     readinessProbe:
       initialDelaySeconds: 200
+  host: semantics.example.org
+  ## If 'authentication' is set to false, no OAuth authentication is enforced
+  authentication: false
+  properties:
+    discoveryfinder:
+      # Initial Endpoint for edc discovery with type bpn
+      initialEndpoints:
+        - type: bpn
+          endpointAddress: https://portal-backend.example.org/api/administration/Connectors/discovery
+          description: Service to discover connector endpoints based on bpns
+          documentation: https://portal-backend.example.org/api/administration/swagger/index.html
+  idp:
+    issuerUri: "https://centralidp.example.org/auth/realms/CX-Central"
+    #publicClientId: ""
+  ingress:
+    enabled: true
+    tls: true
   postgresql:
     nameOverride: "discoveryfinder-postgresql"
 


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

Fixes #58 

add configuration:

- [x] portal (ingress+tls, clientid+secrets, swagger enabled, etc)
- [x] centralidp (ingress+tls, themes)
- [x] sharedidp  (ingress+tls, themes)
- [ ] bpndiscovery
- [x] discoveryfinder (ingress+tls)
- [ ] miw
- [ ] sd-factory
- [ ] vault

update docs (chart readme and description)

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
