### PR TITLE
chore: upgrade portal and iam to 24.03 release

### DIFF
--- a/charts/umbrella/Chart.yaml
+++ b/charts/umbrella/Chart.yaml
@@ -28,7 +28,7 @@ sources:
   - https://github.com/eclipse-tractusx/e2e-testing
 
 type: application
-version: 0.6.0
+version: 0.7.0
 
 dependencies:
 #  # TODO: update edc components to R23.12
@@ -46,16 +46,16 @@ dependencies:
   - condition: portal.enabled
     name: portal
     repository: https://eclipse-tractusx.github.io/charts/dev
-    version: 1.7.0
+    version: 1.8.0
   # cx-iam
   - condition: centralidp.enabled
     name: centralidp
     repository: https://eclipse-tractusx.github.io/charts/dev
-    version: 2.0.0
+    version: 2.1.0
   - condition: sharedidp.enabled
     name: sharedidp
     repository: https://eclipse-tractusx.github.io/charts/dev
-    version: 2.0.0
+    version: 2.1.0
   # discovery-finder
   - condition: discoveryfinder.enabled
     name: discoveryfinder

--- a/charts/umbrella/values.yaml
+++ b/charts/umbrella/values.yaml
@@ -140,6 +140,10 @@
 portal:
   enabled: true
   replicaCount: 1
+  postgresql:
+    postgresql:
+    nameOverride: "portal-backend-postgresql"
+    architecture: standalone
 
 centralidp:
   enabled: true


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description

- upgrade portal and iam to 24.03 release
- also: move to standalone db setup for portal to save resources

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
