### PR TITLE
chore: fix helm checks workflow for client rate limiter error

### DIFF
--- a/.github/workflows/helm-checks.yaml
+++ b/.github/workflows/helm-checks.yaml
@@ -132,8 +132,9 @@ jobs:
       run: ct install --charts charts/simple-data-backend --target-branch ${{ github.event.repository.default_branch }} --helm-extra-set-args "--set image.repository=kind-registry:5000/simple-data-backend --set image.tag=testing"
 
     - name: Install chart and run tests (umbrella)
-      run: ct install --charts charts/umbrella --target-branch ${{ github.event.repository.default_branch }}
-
+      run: |
+        helm install umbrella charts/umbrella --namespace install --create-namespace --debug
+        helm uninstall umbrella --namespace install
 
     ## Skip upgrade for now until a working chart is released
     #- name: Run helm upgrade

--- a/.github/workflows/helm-checks.yaml
+++ b/.github/workflows/helm-checks.yaml
@@ -96,6 +96,9 @@ jobs:
         # default value for event_name != workflow_dispatch
         node_image: ${{ github.event.inputs.node_image || 'kindest/node:v1.27.3' }}
 
+    - name: Informational - describe node
+      run: kubectl describe node
+
     - name: Build simple data backend
       id: build-simple-data-backend
       uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5.1.0

--- a/.github/workflows/helm-checks.yaml
+++ b/.github/workflows/helm-checks.yaml
@@ -89,7 +89,7 @@ jobs:
         fetch-depth: 0
 
     - name: Kubernetes KinD Cluster
-      uses: container-tools/kind-action@v2
+      uses: container-tools/kind-action@0ad70e2299366b0e1552c7240f4e4567148f723e #v2.0.4
       with:
         # upgrade version, default (v0.17.0) uses node image v1.21.1 and doesn't work with more recent node image versions
         version: v0.20.0
@@ -108,7 +108,7 @@ jobs:
         tags: kind-registry:5000/simple-data-backend:testing
 
     - name: Set up Helm
-      uses: azure/setup-helm@v3
+      uses: azure/setup-helm@b7246b12e77f7134dc2d460a3d5bad15bbe29390 # v4.1.0
       with:
         version: ${{ github.event.inputs.helm_version || 'latest' }}
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/helm-checks.yaml
+++ b/.github/workflows/helm-checks.yaml
@@ -58,7 +58,7 @@ jobs:
         fetch-depth: 0
 
     - name: Set up Helm
-      uses: azure/setup-helm@v3
+      uses: azure/setup-helm@b7246b12e77f7134dc2d460a3d5bad15bbe29390 # v4.1.0
       with:
         version: v3.12.1
 

--- a/.github/workflows/helm-checks.yaml
+++ b/.github/workflows/helm-checks.yaml
@@ -111,7 +111,6 @@ jobs:
       uses: azure/setup-helm@b7246b12e77f7134dc2d460a3d5bad15bbe29390 # v4.1.0
       with:
         version: ${{ github.event.inputs.helm_version || 'latest' }}
-        token: ${{ secrets.GITHUB_TOKEN }}
 
     - uses: actions/setup-python@v5
       with:

--- a/charts/umbrella/values.yaml
+++ b/charts/umbrella/values.yaml
@@ -151,7 +151,7 @@ centralidp:
       architecture: standalone
 
 sharedidp:
-  enabled: false
+  enabled: true
   keycloak:
     nameOverride: "sharedidp"
     replicaCount: 1
@@ -190,7 +190,7 @@ discoveryfinder:
     nameOverride: "discoveryfinder-postgresql"
 
 sdfactory:
-  enabled: false
+  enabled: true
   secret:
     # -- JWK Set URI
     jwkSetUri: "https://centralidp.example.org/auth/realms/CX-Central/protocol/openid-connect/certs"

--- a/charts/umbrella/values.yaml
+++ b/charts/umbrella/values.yaml
@@ -151,7 +151,7 @@ centralidp:
       architecture: standalone
 
 sharedidp:
-  enabled: true
+  enabled: false
   keycloak:
     nameOverride: "sharedidp"
     replicaCount: 1
@@ -190,7 +190,7 @@ discoveryfinder:
     nameOverride: "discoveryfinder-postgresql"
 
 sdfactory:
-  enabled: true
+  enabled: false
   secret:
     # -- JWK Set URI
     jwkSetUri: "https://centralidp.example.org/auth/realms/CX-Central/protocol/openid-connect/certs"


### PR DESCRIPTION
### Why

`ct install` step in the helm checks workflow for the umbrella chart kept running into the following error:

```
Error: INSTALLATION FAILED: client rate limiter Wait returned an error: rate: Wait(n=1) would exceed context deadline
```

Presumably due to some cpu throttling in combination with [chart-testing](https://github.com/helm/chart-testing)

## Description

change to `helm install` instead of `ct install` to don't run into that error anymore because when using helm install (also on local Minikube) the chart (for instance for this PR https://github.com/eclipse-tractusx/tractus-x-umbrella/pull/53) installs without error.

also: add an informational step to describe the node for more awareness about available resources in the future and upgrade some actions

### Additional information

I attempted different measure until coming deciding to change to `helm install` instead of `ct install`, for instance I tried to add a timeout to `ct install` but the step then just ran into the same error after the timeout of 30 minutes.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
