### PR TITLE
chore: lower the pvc size for bpndiscovery and discoveryfinder

### DIFF
--- a/charts/umbrella/Chart.yaml
+++ b/charts/umbrella/Chart.yaml
@@ -28,7 +28,7 @@ sources:
   - https://github.com/eclipse-tractusx/tractus-x-umbrella
 
 type: application
-version: 0.11.1
+version: 0.11.2
 
 dependencies:
   # portal

--- a/charts/umbrella/values.yaml
+++ b/charts/umbrella/values.yaml
@@ -407,6 +407,10 @@ bpndiscovery:
       initialDelaySeconds: 200
   postgresql:
     nameOverride: "bpndiscovery-postgresql"
+    primary:
+      persistence:
+        enabled: true
+        size: 8Gi
 
 discoveryfinder:
   enabled: true
@@ -445,6 +449,10 @@ discoveryfinder:
         nginx.ingress.kubernetes.io/x-forwarded-prefix: "/discoveryfinder"
   postgresql:
     nameOverride: "discoveryfinder-postgresql"
+    primary:
+      persistence:
+        enabled: true
+        size: 8Gi
 
 sdfactory:
   enabled: true


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

By default the bpn discovery and discovery finder charts use 50Gi PVCs. It might be reasonable in a production environment but we want to decrease the footprint of the umbrella chart when deploying on a local machine or running tests. Therefore I reduced the PVC sizes to 8Gi.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
