### PR TITLE
chore: rework chart testing and tx-data-provider

### DIFF
--- a/.github/workflows/helm-checks.yaml
+++ b/.github/workflows/helm-checks.yaml
@@ -140,10 +140,15 @@ jobs:
     - name: Install chart and run tests (tx-data-provider)
       run: ct install --charts charts/tx-data-provider --target-branch ${{ github.event.repository.default_branch }}
 
-    - name: Install chart and run tests (umbrella)
+    - name: Install chart for shared services (umbrella)
       run: |
-        helm install umbrella charts/umbrella -f charts/values-test.yaml --namespace install --create-namespace --debug --timeout 10m
-        helm uninstall umbrella --namespace install
+        helm install umbrella charts/umbrella -f charts/values-test-shared-services.yaml --namespace shared-services --create-namespace --debug --timeout 10m
+        helm uninstall umbrella --namespace shared-services
+
+    - name: Install chart for data exchange (umbrella)
+      run: |
+        helm install umbrella charts/umbrella -f charts/values-test-data-exchange.yaml --namespace data-exchange --create-namespace --debug --timeout 10m
+        helm uninstall umbrella --namespace data-exchange
 
     ## Skip upgrade for now until a working chart is released
     #- name: Run helm upgrade

--- a/.github/workflows/helm-checks.yaml
+++ b/.github/workflows/helm-checks.yaml
@@ -142,12 +142,12 @@ jobs:
 
     - name: Install chart for shared services (umbrella)
       run: |
-        helm install umbrella charts/umbrella -f charts/values-test-shared-services.yaml --namespace shared-services --create-namespace --debug --timeout 10m
+        helm install umbrella charts/umbrella -f charts/values-test-shared-services.yaml -f charts/values-test-iam-init-container.yaml --namespace shared-services --create-namespace --debug --timeout 10m
         helm uninstall umbrella --namespace shared-services
 
     - name: Install chart for data exchange (umbrella)
       run: |
-        helm install umbrella charts/umbrella -f charts/values-test-data-exchange.yaml --namespace data-exchange --create-namespace --debug --timeout 10m
+        helm install umbrella charts/umbrella -f charts/values-test-data-exchange.yaml -f charts/values-test-iam-init-container.yaml --namespace data-exchange --create-namespace --debug --timeout 10m
         helm uninstall umbrella --namespace data-exchange
 
     ## Skip upgrade for now until a working chart is released

--- a/charts/umbrella/Chart.yaml
+++ b/charts/umbrella/Chart.yaml
@@ -72,7 +72,6 @@ dependencies:
     condition: dataconsumer.enabled
     # TX Data Providers
   - name: tx-data-provider
-    alias: dataprovider
     version: 0.0.2
     repository: https://eclipse-tractusx.github.io/charts/dev
-    condition: dataprovider.enabled
+    condition: tx-data-provider.enabled

--- a/charts/umbrella/Chart.yaml
+++ b/charts/umbrella/Chart.yaml
@@ -28,7 +28,7 @@ sources:
   - https://github.com/eclipse-tractusx/tractus-x-umbrella
 
 type: application
-version: 0.11.2
+version: 0.11.3
 
 dependencies:
   # portal

--- a/charts/umbrella/README.md
+++ b/charts/umbrella/README.md
@@ -200,10 +200,18 @@ To set your own configuration and secret values, install the helm chart with you
 helm install -f your-values.yaml umbrella tractusx-dev/umbrella --namespace umbrella
 ```
 
-To install only the components currently in focus of the **E2E Adopter Journey**, install the helm chart with the values-adopter.yaml file:
+To install only the components currently in focus of the **E2E Adopter Journey**, install the helm chart with the respective `values-adopter-xxx.yaml` file:
+
+**Data Exchange**
 
 ```bash
-helm install -f values-adopter.yaml umbrella tractusx-dev/umbrella --namespace umbrella
+helm install -f values-adopter-data-exchange.yaml umbrella tractusx-dev/umbrella --namespace umbrella
+```
+
+**Portal**
+
+```bash
+helm install -f values-adopter-portal.yaml umbrella tractusx-dev/umbrella --namespace umbrella
 ```
 
 > **Note**
@@ -213,6 +221,14 @@ helm install -f values-adopter.yaml umbrella tractusx-dev/umbrella --namespace u
 >
 
 ### E2E Adopter Journeys
+
+#### Data exchange
+
+Involved components:
+
+EDC, MIW, DTR, Vault (data provider and consumer in tx-data-provider), CentralIdP.
+
+TBD.
 
 #### Get to know the Portal
 
@@ -260,14 +276,6 @@ tractusx-umbr3lla!
             end
           linkStyle 0,1 stroke:lightblue
 ```
-
-#### Data exchange
-
-Involved components:
-
-EDC, MIW, DTR, Vault (data provider and consumer in tx-data-provider), CentralIdP.
-
-TBD.
 
 ### Uninstall
 

--- a/charts/umbrella/values-adopter-data-exchange.yaml
+++ b/charts/umbrella/values-adopter-data-exchange.yaml
@@ -1,0 +1,46 @@
+# #############################################################################
+# Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# #############################################################################
+---
+
+portal:
+  enabled: false
+
+centralidp:
+  enabled: true
+
+sharedidp:
+  enabled: false
+
+bpndiscovery:
+  enabled: false
+
+discoveryfinder:
+  enabled: false
+
+sdfactory:
+  enabled: false
+
+managed-identity-wallet:
+  enabled: true
+
+dataconsumer:
+  enabled: true
+
+tx-data-provider:
+  enabled: true

--- a/charts/umbrella/values-adopter-portal.yaml
+++ b/charts/umbrella/values-adopter-portal.yaml
@@ -42,5 +42,5 @@ managed-identity-wallet:
 dataconsumer:
   enabled: false
 
-dataprovider:
+tx-data-provider:
   enabled: false

--- a/charts/umbrella/values.yaml
+++ b/charts/umbrella/values.yaml
@@ -583,7 +583,7 @@ dataconsumer:
   simple-data-backend:
     enabled: false
 
-dataprovider:
+tx-data-provider:
   enabled: false
   seedTestdata: true
   backendUrl: http://{{ .Release.Name }}-dataprovider-submodelserver:8080
@@ -639,6 +639,7 @@ dataprovider:
     postgresql:
       nameOverride: dataprovider-dtr-db
       auth:
+        password: "dtrdataproviderpw"
         existingSecret: dataprovider-secret-dtr-postgres-init
     registry:
       host: dataprovider-dtr.test

--- a/charts/umbrella/values.yaml
+++ b/charts/umbrella/values.yaml
@@ -170,7 +170,7 @@ centralidp:
     initContainers:
       - name: realm-import
         image: docker.io/tractusx/umbrella-init-container:0.0.1-init
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         command:
           - sh
         args:
@@ -183,7 +183,7 @@ centralidp:
           mountPath: "/realms"
       - name: theme-import
         image: docker.io/tractusx/portal-iam:v2.1.0
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         command:
           - sh
         args:
@@ -196,7 +196,7 @@ centralidp:
           mountPath: "/themes"
       - name: init-certs
         image: docker.io/bitnami/keycloak:22.0.3-debian-11-r14
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         command: ["/bin/bash"]
         args:
           - -ec
@@ -283,7 +283,7 @@ sharedidp:
     initContainers:
       - name: realm-import
         image: docker.io/tractusx/umbrella-init-container:0.0.1-init
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         command:
           - sh
         args:
@@ -296,7 +296,7 @@ sharedidp:
           mountPath: "/realms"
       - name: theme-import
         image: docker.io/tractusx/portal-iam:v2.1.0
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         command:
           - sh
         args:
@@ -313,7 +313,7 @@ sharedidp:
           mountPath: "/themes-catenax-shared-portal"
       - name: init-certs
         image: docker.io/bitnami/keycloak:22.0.3-debian-11-r14
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         command: ["/bin/bash"]
         args:
           - -ec

--- a/charts/umbrella/values.yaml
+++ b/charts/umbrella/values.yaml
@@ -18,7 +18,7 @@
 # #############################################################################
 ---
 portal:
-  enabled: true
+  enabled: false
   replicaCount: 1
   postgresql:
     postgresql:
@@ -159,7 +159,7 @@ portal:
                 port: 8080
 
 centralidp:
-  enabled: true
+  enabled: false
   keycloak:
     nameOverride: "centralidp"
     replicaCount: 1
@@ -272,7 +272,7 @@ centralidp:
         truststorePassword: ""
 
 sharedidp:
-  enabled: true
+  enabled: false
   keycloak:
     nameOverride: "sharedidp"
     replicaCount: 1
@@ -391,7 +391,7 @@ sharedidp:
         truststorePassword: ""
 
 bpndiscovery:
-  enabled: true
+  enabled: false
   enablePostgres: true
   bpndiscovery:
     authentication: false
@@ -413,7 +413,7 @@ bpndiscovery:
         size: 8Gi
 
 discoveryfinder:
-  enabled: true
+  enabled: false
   enablePostgres: true
   discoveryfinder:
     authentication: true
@@ -455,7 +455,7 @@ discoveryfinder:
         size: 8Gi
 
 sdfactory:
-  enabled: true
+  enabled: false
   secret:
     # -- JWK Set URI
     jwkSetUri: "https://centralidp.example.org/auth/realms/CX-Central/protocol/openid-connect/certs"
@@ -483,7 +483,7 @@ sdfactory:
     clearingHouseClientSecret: ""
 
 managed-identity-wallet:
-  enabled: true
+  enabled: false
   ## TODO figure out tls setup with centralidp keycloak
   miw:
     host: "managed-identity-wallets.example.org"
@@ -532,7 +532,6 @@ managed-identity-wallet:
       nginx.ingress.kubernetes.io/enable-cors: "true"
 
 dataconsumer:
-  # Disable until install works
   enabled: false
   seedTestdata: false
   nameOverride: dataconsumer
@@ -585,7 +584,6 @@ dataconsumer:
     enabled: false
 
 dataprovider:
-  # Disable until install works
   enabled: false
   seedTestdata: true
   backendUrl: http://{{ .Release.Name }}-dataprovider-submodelserver:8080

--- a/charts/values-test-data-exchange.yaml
+++ b/charts/values-test-data-exchange.yaml
@@ -17,7 +17,11 @@
 # SPDX-License-Identifier: Apache-2.0
 ###############################################################
 
+portal:
+  enabled: false
+
 centralidp:
+  enabled: true
   keycloak:
     initContainers:
       - name: import
@@ -35,18 +39,22 @@ centralidp:
           mountPath: "/realms"
 
 sharedidp:
-  keycloak:
-    initContainers:
-      - name: import
-        image: kind-registry:5000/init-container:testing
-        imagePullPolicy: Always
-        command:
-          - sh
-        args:
-          - -c
-          - |
-            echo "Copying realms..."
-            cp -R /import/catenax-shared/realms/* /realms
-        volumeMounts:
-        - name: realms
-          mountPath: "/realms"
+  enabled: false
+
+bpndiscovery:
+  enabled: false
+
+discoveryfinder:
+  enabled: false
+
+sdfactory:
+  enabled: false
+
+managed-identity-wallet:
+  enabled: true
+
+dataconsumer:
+  enabled: false
+
+dataprovider:
+  enabled: false

--- a/charts/values-test-data-exchange.yaml
+++ b/charts/values-test-data-exchange.yaml
@@ -41,5 +41,5 @@ managed-identity-wallet:
 dataconsumer:
   enabled: true
 
-dataprovider:
+tx-data-provider:
   enabled: true

--- a/charts/values-test-iam-init-container.yaml
+++ b/charts/values-test-iam-init-container.yaml
@@ -17,29 +17,36 @@
 # SPDX-License-Identifier: Apache-2.0
 ###############################################################
 
-portal:
-  enabled: false
-
 centralidp:
-  enabled: true
+  keycloak:
+    initContainers:
+      - name: import
+        image: kind-registry:5000/init-container:testing
+        imagePullPolicy: Always
+        command:
+          - sh
+        args:
+          - -c
+          - |
+            echo "Copying realms..."
+            cp -R /import/catenax-central/realms/* /realms
+        volumeMounts:
+        - name: realms
+          mountPath: "/realms"
 
 sharedidp:
-  enabled: false
-
-bpndiscovery:
-  enabled: false
-
-discoveryfinder:
-  enabled: false
-
-sdfactory:
-  enabled: false
-
-managed-identity-wallet:
-  enabled: true
-
-dataconsumer:
-  enabled: true
-
-dataprovider:
-  enabled: true
+  keycloak:
+    initContainers:
+      - name: import
+        image: kind-registry:5000/init-container:testing
+        imagePullPolicy: Always
+        command:
+          - sh
+        args:
+          - -c
+          - |
+            echo "Copying realms..."
+            cp -R /import/catenax-shared/realms/* /realms
+        volumeMounts:
+        - name: realms
+          mountPath: "/realms"

--- a/charts/values-test-shared-services.yaml
+++ b/charts/values-test-shared-services.yaml
@@ -22,39 +22,9 @@ portal:
 
 centralidp:
   enabled: true
-  keycloak:
-    initContainers:
-      - name: import
-        image: kind-registry:5000/init-container:testing
-        imagePullPolicy: Always
-        command:
-          - sh
-        args:
-          - -c
-          - |
-            echo "Copying realms..."
-            cp -R /import/catenax-central/realms/* /realms
-        volumeMounts:
-        - name: realms
-          mountPath: "/realms"
 
 sharedidp:
   enabled: true
-  keycloak:
-    initContainers:
-      - name: import
-        image: kind-registry:5000/init-container:testing
-        imagePullPolicy: Always
-        command:
-          - sh
-        args:
-          - -c
-          - |
-            echo "Copying realms..."
-            cp -R /import/catenax-shared/realms/* /realms
-        volumeMounts:
-        - name: realms
-          mountPath: "/realms"
 
 bpndiscovery:
   enabled: true

--- a/charts/values-test-shared-services.yaml
+++ b/charts/values-test-shared-services.yaml
@@ -41,5 +41,5 @@ managed-identity-wallet:
 dataconsumer:
   enabled: false
 
-dataprovider:
+tx-data-provider:
   enabled: false

--- a/charts/values-test-shared-services.yaml
+++ b/charts/values-test-shared-services.yaml
@@ -1,0 +1,75 @@
+###############################################################
+# Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+###############################################################
+
+portal:
+  enabled: true
+
+centralidp:
+  enabled: true
+  keycloak:
+    initContainers:
+      - name: import
+        image: kind-registry:5000/init-container:testing
+        imagePullPolicy: Always
+        command:
+          - sh
+        args:
+          - -c
+          - |
+            echo "Copying realms..."
+            cp -R /import/catenax-central/realms/* /realms
+        volumeMounts:
+        - name: realms
+          mountPath: "/realms"
+
+sharedidp:
+  enabled: true
+  keycloak:
+    initContainers:
+      - name: import
+        image: kind-registry:5000/init-container:testing
+        imagePullPolicy: Always
+        command:
+          - sh
+        args:
+          - -c
+          - |
+            echo "Copying realms..."
+            cp -R /import/catenax-shared/realms/* /realms
+        volumeMounts:
+        - name: realms
+          mountPath: "/realms"
+
+bpndiscovery:
+  enabled: true
+
+discoveryfinder:
+  enabled: true
+
+sdfactory:
+  enabled: true
+
+managed-identity-wallet:
+  enabled: true
+
+dataconsumer:
+  enabled: false
+
+dataprovider:
+  enabled: false


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

fix tx-data-provider: 
- allow provider and consumer being enabled at the same time (relates to https://github.com/eclipse-tractusx/tractus-x-umbrella/pull/67)
- adjust adopter values files and docs

chart testing: 
- split install into shared-services and data-exchange
- disable all components in default values file

chore(iam): change to imagePullPolicy IfNotPresent

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
