### PR TITLE
chore(miw): enable https connection with centralidp

### DIFF
--- a/charts/umbrella/Chart.yaml
+++ b/charts/umbrella/Chart.yaml
@@ -28,7 +28,7 @@ sources:
   - https://github.com/eclipse-tractusx/tractus-x-umbrella
 
 type: application
-version: 0.11.5
+version: 0.11.6
 
 # when adding or updating versions of dependencies, also update list under README.md#Install
 dependencies:

--- a/charts/umbrella/values.yaml
+++ b/charts/umbrella/values.yaml
@@ -493,7 +493,36 @@ sdfactory:
 
 managed-identity-wallet:
   enabled: false
-  ## TODO figure out tls setup with centralidp keycloak
+  # TLS to trust centralidp Keycloak instance
+  initContainers:
+    - name: init-certs
+      image: docker.io/tractusx/managed-identity-wallet:0.4.0
+      imagePullPolicy: IfNotPresent
+      command: ["sh"]
+      args:
+        - -ec
+        - |-
+          cp -R /opt/java/openjdk/lib/security/* /cacerts/
+          echo "Copying done"
+          keytool -import -noprompt -trustcacerts -alias local -file /certs/tls.crt -keystore /cacerts/cacerts -storepass changeit
+          keytool -list -keystore /cacerts/cacerts -alias local
+      volumeMounts:
+        - name: certificates
+          mountPath: /certs
+        - name: shared-certs
+          mountPath: /cacerts
+  extraVolumes:
+    - name: certificates
+      secret:
+        secretName: root-secret
+        defaultMode: 420
+    - name: shared-certs
+      emptyDir: {}
+  extraVolumeMounts:
+    - name: certificates
+      mountPath: /certs
+    - name: shared-certs
+      mountPath: /opt/java/openjdk/lib/security
   miw:
     host: "managed-identity-wallets.example.org"
     authorityWallet:


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

add tls.crt to truststore from miw to enable https connection with centralidp Keycloak instance

to not run into the following exception at managed-identity-wallet:
  "status": 500,
  "error": "Internal Server Error"
`PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target`


https://github.com/eclipse-tractusx/sig-release/issues/418

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
