### PR TITLE
chore: change from example.org to tx.test

### DIFF
--- a/charts/umbrella/Chart.yaml
+++ b/charts/umbrella/Chart.yaml
@@ -28,7 +28,7 @@ sources:
   - https://github.com/eclipse-tractusx/tractus-x-umbrella
 
 type: application
-version: 0.11.6
+version: 0.12.0
 
 # when adding or updating versions of dependencies, also update list under README.md#Install
 dependencies:

--- a/charts/umbrella/README.md
+++ b/charts/umbrella/README.md
@@ -66,7 +66,7 @@ And execute installation step [3 Add the `minikube ip` as a DNS server](https://
 Create a file in /etc/resolver/minikube-test with the following contents.
 
 ```
-domain example.org
+domain tx.test
 nameserver 192.168.49.2
 search_order 1
 timeout 5
@@ -82,12 +82,12 @@ minikube ip
 If you still face DNS issues afterwards, add the hosts to your /etc/hosts file:
 
 ```
-192.168.49.2    centralidp.example.org
-192.168.49.2    sharedidp.example.org
-192.168.49.2    portal.example.org
-192.168.49.2    portal-backend.example.org
-192.168.49.2    managed-identity-wallets.example.org
-192.168.49.2    semantics.example.org
+192.168.49.2    centralidp.tx.test
+192.168.49.2    sharedidp.tx.test
+192.168.49.2    portal.tx.test
+192.168.49.2    portal-backend.tx.test
+192.168.49.2    managed-identity-wallets.tx.test
+192.168.49.2    semantics.tx.test
 ```
 
 Replace 192.168.49.2 with your minikube ip.
@@ -134,7 +134,7 @@ metadata:
   namespace: umbrella
 spec:
   isCA: true
-  commonName: cx.local
+  commonName: tx.test
   secretName: root-secret
   privateKey:
     algorithm: RSA
@@ -290,17 +290,17 @@ TBD.
 Perform first login and send out an invite to a company to join the network (SMTP account required to be configured in custom values.yaml file).
 
 Make sure to accept the risk of the self-signed certificates for the following hosts using the continue option:
-- [centralidp.example.org/auth/](https://centralidp.example.org/auth/)
-- [sharedidp.example.org/auth/](https://sharedidp.example.org/auth/)
-- [portal-backend.example.org](https://portal-backend.example.org)
-- [portal.example.org](https://portal.example.org)
+- [centralidp.tx.test/auth/](https://centralidp.tx.test/auth/)
+- [sharedidp.tx.test/auth/](https://sharedidp.tx.test/auth/)
+- [portal-backend.tx.test](https://portal-backend.tx.test)
+- [portal.tx.test](https://portal.tx.test)
 
-Then proceed with the login to the [portal](https://portal.example.org) to verify that everything is setup as expected.
+Then proceed with the login to the [portal](https://portal.tx.test) to verify that everything is setup as expected.
 
 Credentials to log into the initial example realm (CX-Operator):
 
 ```
-cx-operator@example.org
+cx-operator@tx.test
 ```
 
 ```
@@ -348,17 +348,17 @@ helm delete umbrella --namespace umbrella
 
 Currently enabled ingresses:
 
-- https://centralidp.example.org/auth/
-- https://sharedidp.example.org/auth/
-- https://portal-backend.example.org
-  - https://portal-backend.example.org/api/administration/swagger/index.html
-  - https://portal-backend.example.org/api/registration/swagger/index.html
-  - https://portal-backend.example.org/api/apps/swagger/index.html
-  - https://portal-backend.example.org/api/services/swagger/index.html
-  - https://portal-backend.example.org/api/notification/swagger/index.html
-- https://portal.example.org
-- https://managed-identity-wallets.example.org/ui/swagger-ui/index.html
-- https://semantics.example.org/discoveryfinder/swagger-ui/index.html
+- https://centralidp.tx.test/auth/
+- https://sharedidp.tx.test/auth/
+- https://portal-backend.tx.test
+  - https://portal-backend.tx.test/api/administration/swagger/index.html
+  - https://portal-backend.tx.test/api/registration/swagger/index.html
+  - https://portal-backend.tx.test/api/apps/swagger/index.html
+  - https://portal-backend.tx.test/api/services/swagger/index.html
+  - https://portal-backend.tx.test/api/notification/swagger/index.html
+- https://portal.tx.test
+- https://managed-identity-wallets.tx.test/ui/swagger-ui/index.html
+- https://semantics.tx.test/discoveryfinder/swagger-ui/index.html
 
 ### Seeding
 

--- a/charts/umbrella/values.yaml
+++ b/charts/umbrella/values.yaml
@@ -27,17 +27,17 @@ portal:
     primary:
       persistence:
         enabled: false
-  portalAddress: "https://portal.example.org"
-  portalBackendAddress: "https://portal-backend.example.org"
-  centralidpAddress: "https://centralidp.example.org"
-  sharedidpAddress: "https://sharedidp.example.org"
-  semanticsAddress: "https://semantics.example.org"
-  bpdmPartnersPoolAddress: "https://business-partners.example.org"
-  bpdmPortalGateAddress: "https://business-partners.example.org"
-  custodianAddress: "https://managed-identity-wallets.example.org"
-  sdfactoryAddress: "https://sdfactory.example.org"
-  clearinghouseAddress: "https://validation.example.org"
-  clearinghouseTokenAddress: "https://keycloak.example.org/realms/example/protocol/openid-connect/token"
+  portalAddress: "https://portal.tx.test"
+  portalBackendAddress: "https://portal-backend.tx.test"
+  centralidpAddress: "https://centralidp.tx.test"
+  sharedidpAddress: "https://sharedidp.tx.test"
+  semanticsAddress: "https://semantics.tx.test"
+  bpdmPartnersPoolAddress: "https://business-partners.tx.test"
+  bpdmPortalGateAddress: "https://business-partners.tx.test"
+  custodianAddress: "https://managed-identity-wallets.tx.test"
+  sdfactoryAddress: "https://sdfactory.tx.test"
+  clearinghouseAddress: "https://validation.tx.test"
+  clearinghouseTokenAddress: "https://keycloak.tx.test/realms/example/protocol/openid-connect/token"
   frontend:
     ingress:
       enabled: true
@@ -46,15 +46,15 @@ portal:
         nginx.ingress.kubernetes.io/rewrite-target: "/$1"
         nginx.ingress.kubernetes.io/use-regex: "true"
         nginx.ingress.kubernetes.io/enable-cors: "true"
-        nginx.ingress.kubernetes.io/cors-allow-origin: "https://*.example.org"
+        nginx.ingress.kubernetes.io/cors-allow-origin: "https://*.tx.test"
       tls:
         # -- Provide tls secret.
-        - secretName: "portal.example.org-tls"
+        - secretName: "portal.tx.test-tls"
           # -- Provide host for tls secret.
           hosts:
-            - "portal.example.org"
+            - "portal.tx.test"
       hosts:
-        - host: "portal.example.org"
+        - host: "portal.tx.test"
           paths:
             - path: "/(.*)"
               pathType: "ImplementationSpecific"
@@ -93,25 +93,25 @@ portal:
     notification:
       swaggerEnabled: true
     mailing:
-      host: "smtp.example.org"
+      host: "smtp.tx.test"
       port: "587"
       user: "smtp-user"
-      senderEmail: "smtp@example.org"
+      senderEmail: "smtp@tx.test"
       password: ""
     provisioning:
       sharedRealm:
         smtpServer:
-          host: "smtp.example.org"
+          host: "smtp.tx.test"
           port: "587"
           user: "smtp-user"
           password: ""
-          from: "smtp@example.org"
-          replyTo: "smtp@example.org"
-    # -- docs: https://portal-backend.example.org/api/administration/swagger/index.html
-    # https://portal-backend.example.org/api/registration/swagger/index.html
-    # https://portal-backend.example.org/api/apps/swagger/index.html
-    # https://portal-backend.example.org/api/services/swagger/index.html
-    # https://portal-backend.example.org/api/notification/swagger/index.html
+          from: "smtp@tx.test"
+          replyTo: "smtp@tx.test"
+    # -- docs: https://portal-backend.tx.test/api/administration/swagger/index.html
+    # https://portal-backend.tx.test/api/registration/swagger/index.html
+    # https://portal-backend.tx.test/api/apps/swagger/index.html
+    # https://portal-backend.tx.test/api/services/swagger/index.html
+    # https://portal-backend.tx.test/api/notification/swagger/index.html
     ingress:
       enabled: true
       name: "portal-backend"
@@ -120,15 +120,15 @@ portal:
         nginx.ingress.kubernetes.io/use-regex: "true"
         nginx.ingress.kubernetes.io/enable-cors: "true"
         nginx.ingress.kubernetes.io/proxy-body-size: "8m"
-        nginx.ingress.kubernetes.io/cors-allow-origin: "http://localhost:3000, https://*.example.org"
+        nginx.ingress.kubernetes.io/cors-allow-origin: "http://localhost:3000, https://*.tx.test"
       tls:
         # -- Provide tls secret.
-        - secretName: "portal-backend.example.org-tls"
+        - secretName: "portal-backend.tx.test-tls"
           # -- Provide host for tls secret.
           hosts:
-            - "portal-backend.example.org"
+            - "portal-backend.tx.test"
       hosts:
-        - host: "portal-backend.example.org"
+        - host: "portal-backend.tx.test"
           paths:
             - path: "/api/registration"
               pathType: "Prefix"
@@ -175,7 +175,7 @@ centralidp:
     proxy: edge
     initContainers:
       - name: realm-import
-        image: docker.io/tractusx/umbrella-init-container:0.0.1-init
+        image: docker.io/tractusx/umbrella-init-container:0.0.2-init
         imagePullPolicy: IfNotPresent
         command:
           - sh
@@ -257,12 +257,12 @@ centralidp:
     ingress:
       enabled: true
       ingressClassName: "nginx"
-      hostname: "centralidp.example.org"
+      hostname: "centralidp.tx.test"
       annotations:
         cert-manager.io/cluster-issuer: "my-ca-issuer"
         nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
         nginx.ingress.kubernetes.io/cors-allow-methods: "PUT, GET, POST, OPTIONS"
-        nginx.ingress.kubernetes.io/cors-allow-origin: "https://centralidp.example.org"
+        nginx.ingress.kubernetes.io/cors-allow-origin: "https://centralidp.tx.test"
         nginx.ingress.kubernetes.io/enable-cors: "true"
         nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
         nginx.ingress.kubernetes.io/proxy-buffering: "on"
@@ -291,7 +291,7 @@ sharedidp:
     proxy: edge
     initContainers:
       - name: realm-import
-        image: docker.io/tractusx/umbrella-init-container:0.0.1-init
+        image: docker.io/tractusx/umbrella-init-container:0.0.2-init
         imagePullPolicy: IfNotPresent
         command:
           - sh
@@ -379,12 +379,12 @@ sharedidp:
     ingress:
       enabled: true
       ingressClassName: "nginx"
-      hostname: "sharedidp.example.org"
+      hostname: "sharedidp.tx.test"
       annotations:
         cert-manager.io/cluster-issuer: "my-ca-issuer"
         nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
         nginx.ingress.kubernetes.io/cors-allow-methods: "PUT, GET, POST, OPTIONS"
-        nginx.ingress.kubernetes.io/cors-allow-origin: "https://sharedidp.example.org"
+        nginx.ingress.kubernetes.io/cors-allow-origin: "https://sharedidp.tx.test"
         nginx.ingress.kubernetes.io/enable-cors: "true"
         nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
         nginx.ingress.kubernetes.io/proxy-buffering: "on"
@@ -430,20 +430,20 @@ discoveryfinder:
       initialDelaySeconds: 200
     readinessProbe:
       initialDelaySeconds: 200
-    host: semantics.example.org
+    host: semantics.tx.test
     properties:
       discoveryfinder:
         initialEndpoints:
           - type: bpn
-            endpointAddress: https://portal-backend.example.org/api/administration/Connectors/discovery
+            endpointAddress: https://portal-backend.tx.test/api/administration/Connectors/discovery
             description: Service to discover connector endpoints based on bpns
-            documentation: https://portal-backend.example.org/api/administration/swagger/index.html
+            documentation: https://portal-backend.tx.test/api/administration/swagger/index.html
     idp:
-      issuerUri: "https://centralidp.example.org/auth/realms/CX-Central"
+      issuerUri: "https://centralidp.tx.test/auth/realms/CX-Central"
       publicClientId: "Cl21-CX-DF"
     dataSource:
       url: "jdbc:postgresql://{{ .Release.Name }}-discoveryfinder-postgresql:5432/discoveryfinder"
-    # -- docs: https://semantics.example.org/discoveryfinder/swagger-ui/index.html
+    # -- docs: https://semantics.tx.test/discoveryfinder/swagger-ui/index.html
     ingress:
       enabled: true
       tls: true
@@ -467,13 +467,13 @@ sdfactory:
   enabled: false
   secret:
     # -- JWK Set URI
-    jwkSetUri: "https://centralidp.example.org/auth/realms/CX-Central/protocol/openid-connect/certs"
+    jwkSetUri: "https://centralidp.tx.test/auth/realms/CX-Central/protocol/openid-connect/certs"
     # -- Custodian wallet client id
     clientId: ""
     # -- Custodian wallet client secret
     clientSecret: ""
     # -- Keycloak URL
-    authServerUrl: "https://centralidp.example.org/auth"
+    authServerUrl: "https://centralidp.tx.test/auth"
     # -- Keycloak Realm detail
     realm: ""
     # -- Keycloak Resource detail
@@ -524,7 +524,7 @@ managed-identity-wallet:
     - name: shared-certs
       mountPath: /opt/java/openjdk/lib/security
   miw:
-    host: "managed-identity-wallets.example.org"
+    host: "managed-identity-wallets.tx.test"
     authorityWallet:
       bpn: &authority-bpn "BPNL00000003CRHK"
       name: "Catena-X"
@@ -532,7 +532,7 @@ managed-identity-wallet:
       host: "{{ .Release.Name }}-miw-postgres"
       secret: "{{ .Release.Name }}-miw-postgres"
     keycloak:
-      url: "https://centralidp.example.org/auth"
+      url: "https://centralidp.tx.test/auth"
       realm: "CX-Central"
       clientId: &miw_client "Cl5-CX-Custodian"
     ssi:
@@ -549,22 +549,22 @@ managed-identity-wallet:
     initialDelaySeconds: 90
   readinessProbe:
     initialDelaySeconds: 90
-  # -- docs: https://managed-identity-wallets.example.org/ui/swagger-ui/index.html
+  # -- docs: https://managed-identity-wallets.tx.test/ui/swagger-ui/index.html
   ingress:
     enabled: true
     hosts:
-      - host: "managed-identity-wallets.example.org"
+      - host: "managed-identity-wallets.tx.test"
         paths:
           - path: "/"
             pathType: "ImplementationSpecific"
     tls:
-      - secretName: "managed-identity-wallets.example.org-tls"
+      - secretName: "managed-identity-wallets.tx.test-tls"
         hosts:
-          - "managed-identity-wallets.example.org"
+          - "managed-identity-wallets.tx.test"
     className: "nginx"
     annotations:
       cert-manager.io/cluster-issuer: "my-ca-issuer"
-      nginx.ingress.kubernetes.io/cors-allow-origin: https://portal.example.org
+      nginx.ingress.kubernetes.io/cors-allow-origin: https://portal.tx.test
       nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
       nginx.ingress.kubernetes.io/cors-allow-methods: GET
       nginx.ingress.kubernetes.io/enable-cors: "true"
@@ -582,10 +582,10 @@ dataconsumer:
     controlplane:
       ssi:
         miw:
-          url: https://managed-identity-wallets.example.org
+          url: https://managed-identity-wallets.tx.test
           authorityId: BPNL00000003CRHK
         oauth:
-          tokenurl: https://centralidp.example.org/auth/realms/CX-Central/protocol/openid-connect/token
+          tokenurl: https://centralidp.tx.test/auth/realms/CX-Central/protocol/openid-connect/token
           client:
             id: *miw_client
             secretAlias: edc-miw-keycloak-secret
@@ -594,7 +594,7 @@ dataconsumer:
           authKey: TEST1
       ingresses:
         - enabled: true
-          hostname: "dataconsumer-controlplane.example.org"
+          hostname: "dataconsumer-controlplane.tx.test"
           endpoints:
             - default
             - protocol
@@ -605,7 +605,7 @@ dataconsumer:
     dataplane:
       ingresses:
         - enabled: true
-          hostname: "dataconsumer-dataplane.example.org"
+          hostname: "dataconsumer-dataplane.tx.test"
           endpoints:
             - default
             - public
@@ -654,10 +654,10 @@ tx-data-provider:
     controlplane:
       ssi:
         miw:
-          url: https://managed-identity-wallets.example.org
+          url: https://managed-identity-wallets.tx.test
           authorityId: BPNL00000003CRHK
         oauth:
-          tokenurl: https://centralidp.example.org/auth/realms/CX-Central/protocol/openid-connect/token
+          tokenurl: https://centralidp.tx.test/auth/realms/CX-Central/protocol/openid-connect/token
           client:
             id: *miw_client
             secretAlias: edc-miw-keycloak-secret
@@ -666,7 +666,7 @@ tx-data-provider:
           authKey: TEST2
       ingresses:
         - enabled: true
-          hostname: "dataprovider-controlplane.example.org"
+          hostname: "dataprovider-controlplane.tx.test"
           endpoints:
             - default
             - protocol
@@ -677,7 +677,7 @@ tx-data-provider:
     dataplane:
       ingresses:
         - enabled: true
-          hostname: "dataprovider-dataplane.example.org"
+          hostname: "dataprovider-dataplane.tx.test"
           endpoints:
             - default
             - public

--- a/concept/seeds-overall-data.md
+++ b/concept/seeds-overall-data.md
@@ -4,21 +4,21 @@
 
 ### Base addresses
 
-- portal base address - portalAddress: "<https://portal.example.org>"
-- portal-backend base address - portalBackendAddress: "<https://portal-backend.example.org>"
-- centralidp base address (CX IAM) - centralidpAddress: "<https://centralidp.example.org>"
-- sharedidp address (CX IAM) - sharedidpAddress: "<https://sharedidp.example.org>"
-- semantics base address - semanticsAddress: "<https://semantics.example.org>"
-- bpdm partners pool base address - bpdmPartnersPoolAddress: "<https://business-partners.example.org>"
-- bpdm portal gate base address - bpdmPortalGateAddress: "<https://business-partners.example.org>"
-- custodian base address - custodianAddress: "<https://managed-identity-wallets.example.org>"
-- sdfactory base address - sdfactoryAddress: "<https://sdfactory.example.org>"
-- clearinghouse base address - clearinghouseAddress: "<https://validation.example.org>"
-- clearinghouse token address - clearinghouseTokenAddress: "<https://keycloak.example.org/realms/example/protocol/openid-connect/token>"
+- portal base address - portalAddress: "<https://portal.tx.test>"
+- portal-backend base address - portalBackendAddress: "<https://portal-backend.tx.test>"
+- centralidp base address (CX IAM) - centralidpAddress: "<https://centralidp.tx.test>"
+- sharedidp address (CX IAM) - sharedidpAddress: "<https://sharedidp.tx.test>"
+- semantics base address - semanticsAddress: "<https://semantics.tx.test>"
+- bpdm partners pool base address - bpdmPartnersPoolAddress: "<https://business-partners.tx.test>"
+- bpdm portal gate base address - bpdmPortalGateAddress: "<https://business-partners.tx.test>"
+- custodian base address - custodianAddress: "<https://managed-identity-wallets.tx.test>"
+- sdfactory base address - sdfactoryAddress: "<https://sdfactory.tx.test>"
+- clearinghouse base address - clearinghouseAddress: "<https://validation.tx.test>"
+- clearinghouse token address - clearinghouseTokenAddress: "<https://keycloak.tx.test/realms/example/protocol/openid-connect/token>"
 
 ### Token Address
 
-- "<https://centralidp.example.org/auth/realms/CX-Central/protocol/openid-connect/token>"
+- "<https://centralidp.tx.test/auth/realms/CX-Central/protocol/openid-connect/token>"
 
 ## Companies and BPNs
 

--- a/init-container/iam/centralidp/CX-Central-realm.json
+++ b/init-container/iam/centralidp/CX-Central-realm.json
@@ -2365,7 +2365,7 @@
       "emailVerified" : false,
       "firstName" : "Operator",
       "lastName" : "CX Admin",
-      "email" : "tobeadded@example.org",
+      "email" : "tobeadded@tx.test",
       "attributes" : {
         "bpn" : [ "BPNL00000003CRHK" ],
         "organisation" : [ "CX-Operator" ]
@@ -2376,7 +2376,7 @@
       "federatedIdentities" : [ {
         "identityProvider" : "CX-Operator",
         "userId" : "656e8a94-188b-4a3e-9eec-b45d8efd8347",
-        "userName" : "cx-operator@example.org"
+        "userName" : "cx-operator@tx.test"
       } ],
       "realmRoles" : [ "default-roles-catena-x realm" ],
       "clientRoles" : {
@@ -3495,7 +3495,7 @@
       "clientAuthenticatorType": "client-secret",
       "secret": "q0ma25iV6bfqV6ho3kyWKnR1trp0IRez",
       "redirectUris": [
-        "https://partners-gate.example.org/*"
+        "https://partners-gate.tx.test/*"
       ],
       "webOrigins": [
         "+"
@@ -3561,7 +3561,7 @@
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
       "redirectUris": [
-        "https://portal.example.org/*"
+        "https://portal.tx.test/*"
       ],
       "webOrigins": [
         "+"
@@ -3858,7 +3858,7 @@
       "clientId": "Cl2-CX-Portal",
       "name": "",
       "description": "",
-      "rootUrl": "https://portal.example.org/home",
+      "rootUrl": "https://portal.tx.test/home",
       "adminUrl": "",
       "baseUrl": "",
       "surrogateAuthRequired": false,
@@ -3866,7 +3866,7 @@
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
       "redirectUris": [
-        "https://portal.example.org/*"
+        "https://portal.tx.test/*"
       ],
       "webOrigins": [
         "+"
@@ -3955,13 +3955,13 @@
       "id": "36e2745d-f331-4fa5-bbfa-90947d7f1dc4",
       "clientId": "Cl3-CX-Semantic",
       "rootUrl": "",
-      "adminUrl": "https://portal.example.org/home",
+      "adminUrl": "https://portal.tx.test/home",
       "surrogateAuthRequired": false,
       "enabled": true,
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
       "redirectUris": [
-        "https://portal.example.org/*"
+        "https://portal.tx.test/*"
       ],
       "webOrigins": [
         "+"
@@ -4056,7 +4056,7 @@
       "clientAuthenticatorType": "client-secret",
       "secret": "XzZNs56cadY8b2P253By8GS4jbY7QCui",
       "redirectUris": [
-        "https://managed-identity-wallets.example.org/*"
+        "https://managed-identity-wallets.tx.test/*"
       ],
       "webOrigins": [],
       "notBefore": 0,
@@ -4159,7 +4159,7 @@
       "clientAuthenticatorType": "client-secret",
       "secret": "4pJIiaUsLeQsSH6OEqoZmq6aEsZkeBj2",
       "redirectUris": [
-        "https://partners-pool.example.org/*"
+        "https://partners-pool.tx.test/*"
       ],
       "webOrigins": [
         "+"
@@ -8138,11 +8138,11 @@
         "hideOnLoginPage": "false",
         "validateSignature": "true",
         "clientId": "central-idp",
-        "tokenUrl": "https://sharedidp.example.org/auth/realms/CX-Operator/protocol/openid-connect/token",
-        "jwksUrl": "https://sharedidp.example.org/auth/realms/CX-Operator/protocol/openid-connect/certs",
-        "authorizationUrl": "https://sharedidp.example.org/auth/realms/CX-Operator/protocol/openid-connect/auth",
+        "tokenUrl": "https://sharedidp.tx.test/auth/realms/CX-Operator/protocol/openid-connect/token",
+        "jwksUrl": "https://sharedidp.tx.test/auth/realms/CX-Operator/protocol/openid-connect/certs",
+        "authorizationUrl": "https://sharedidp.tx.test/auth/realms/CX-Operator/protocol/openid-connect/auth",
         "clientAuthMethod": "private_key_jwt",
-        "logoutUrl": "https://sharedidp.example.org/auth/realms/CX-Operator/protocol/openid-connect/logout",
+        "logoutUrl": "https://sharedidp.tx.test/auth/realms/CX-Operator/protocol/openid-connect/logout",
         "clientAssertionSigningAlg": "RS256",
         "syncMode": "FORCE",
         "useJwksUrl": "true"

--- a/init-container/iam/sharedidp/CX-Operator-realm.json
+++ b/init-container/iam/sharedidp/CX-Operator-realm.json
@@ -657,7 +657,7 @@
       "clientAuthenticatorType": "client-jwt",
       "secret": "**********",
       "redirectUris": [
-        "https://centralidp.example.org/auth/realms/CX-Central/broker/CX-Operator/endpoint/*"
+        "https://centralidp.tx.test/auth/realms/CX-Central/broker/CX-Operator/endpoint/*"
       ],
       "webOrigins": [
         "+"
@@ -674,7 +674,7 @@
       "protocol": "openid-connect",
       "attributes": {
         "backchannel.logout.session.required": "true",
-        "jwks.url": "https://centralidp.example.org/auth/realms/CX-Central/protocol/openid-connect/certs",
+        "jwks.url": "https://centralidp.tx.test/auth/realms/CX-Central/protocol/openid-connect/certs",
         "token.endpoint.auth.signing.alg": "RS256",
         "post.logout.redirect.uris": "+",
         "use.jwks.url": "true",

--- a/init-container/iam/sharedidp/CX-Operator-users-0.json
+++ b/init-container/iam/sharedidp/CX-Operator-users-0.json
@@ -2,13 +2,13 @@
   "realm" : "CX-Operator",
   "users" : [ {
     "id" : "656e8a94-188b-4a3e-9eec-b45d8efd8347",
-    "username" : "cx-operator@example.org",
+    "username" : "cx-operator@tx.test",
     "enabled" : true,
     "totp" : false,
     "emailVerified" : false,
     "firstName" : "Test User",
     "lastName" : "CX Operator",
-    "email" : "cx-operator@example.org",
+    "email" : "cx-operator@tx.test",
     "credentials" : [ {
       "id" : "02afe9d5-7315-465a-8949-ef0f4db14af0",
       "type" : "password",


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

### Description

- change from `example.org` to `tx.test` as test domain

### Why

`example.org` is a reserved (2nd level) domain (for documentation purposes) and therefore it's not optimal for dns resolution.
This change may make the editing of the etc/hosts file less necessary: https://github.com/eclipse-tractusx/tractus-x-umbrella/blob/main/charts/umbrella/README.md#network-setup

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

https://github.com/eclipse-tractusx/sig-release/issues/418

## Pre-review checks

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
