### PR TITLE
fix(dataexchange): change to http connection and add config

### DIFF
--- a/charts/umbrella/Chart.yaml
+++ b/charts/umbrella/Chart.yaml
@@ -28,7 +28,7 @@ sources:
   - https://github.com/eclipse-tractusx/tractus-x-umbrella
 
 type: application
-version: 0.12.0
+version: 0.12.1
 
 # when adding or updating versions of dependencies, also update list under README.md#Install
 dependencies:

--- a/charts/umbrella/values-adopter-data-exchange.yaml
+++ b/charts/umbrella/values-adopter-data-exchange.yaml
@@ -18,32 +18,47 @@
 # #############################################################################
 ---
 
-portal:
-  enabled: false
-
 centralidp:
   enabled: true
-  # -- uncomment the following for persistance
-  # keycloak:
-  #   postgresql:
-  #     primary:
-  #       persistence:
-  #         enabled: true
-
-sharedidp:
-  enabled: false
-
-bpndiscovery:
-  enabled: false
-
-discoveryfinder:
-  enabled: false
-
-sdfactory:
-  enabled: false
+  keycloak:
+    ingress:
+      enabled: true
+      ingressClassName: "nginx"
+      hostname: "centralidp.tx.test"
+      annotations:
+        nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
+        nginx.ingress.kubernetes.io/cors-allow-methods: "PUT, GET, POST, OPTIONS"
+        nginx.ingress.kubernetes.io/cors-allow-origin: "http://centralidp.tx.test"
+        nginx.ingress.kubernetes.io/enable-cors: "true"
+        nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+        nginx.ingress.kubernetes.io/proxy-buffering: "on"
+        nginx.ingress.kubernetes.io/proxy-buffers-number: "20"
+        nginx.ingress.kubernetes.io/use-regex: "true"
+      tls: false
+    # -- uncomment the following for persistance
+    # postgresql:
+    #   primary:
+    #     persistence:
+    #       enabled: true
 
 managed-identity-wallet:
   enabled: true
+  miw:
+    keycloak:
+      url: "http://centralidp.tx.test/auth"
+  ingress:
+    enabled: true
+    hosts:
+      - host: "managed-identity-wallets.tx.test"
+        paths:
+          - path: "/"
+            pathType: "ImplementationSpecific"
+    className: "nginx"
+    annotations:
+      nginx.ingress.kubernetes.io/cors-allow-origin: http://portal.tx.test
+      nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
+      nginx.ingress.kubernetes.io/cors-allow-methods: GET
+      nginx.ingress.kubernetes.io/enable-cors: "true"
   # -- uncomment the following for persistance
   # postgresql:
   #   primary:
@@ -52,21 +67,86 @@ managed-identity-wallet:
 
 dataconsumer:
   enabled: true
-  # -- uncomment the following for persistance
-  # tractusx-connector:
-  #   postgresql:
-  #     primary:
-  #       persistence:
-  #         enabled: true
+  secrets:
+    edc-miw-keycloak-secret: UbfW4CR1xH4OskkovqJ2JzcwnQIrG7oj
+  tractusx-connector:
+    participant:
+      id: BPNL00000003AZQP
+    controlplane:
+      ssi:
+        miw:
+          url: http://managed-identity-wallets.tx.test
+          authorityId: BPNL00000003CRHK
+        oauth:
+          tokenurl: http://centralidp.tx.test/auth/realms/CX-Central/protocol/openid-connect/token
+          client:
+            id: satest01
+      endpoints:
+        management:
+          authKey: TEST1
+      ingresses:
+        - enabled: true
+          hostname: "dataconsumer-controlplane.tx.test"
+          endpoints:
+            - default
+            - protocol
+            - management
+          tls:
+            enabled: false
+    dataplane:
+      ingresses:
+        - enabled: true
+          hostname: "dataconsumer-dataplane.tx.test"
+          endpoints:
+            - default
+            - public
+          tls:
+            enabled: false
+    # -- uncomment the following for persistance
+    # postgresql:
+    #   primary:
+    #     persistence:
+    #       enabled: true
 
 tx-data-provider:
   enabled: true
+  secrets:
+    edc-miw-keycloak-secret: pyFUZP2L9UCSVJUScHcN3ZEgy2PGyEpg
+  tractusx-connector:
+    participant:
+      id: BPNL00000003AYRE
+    controlplane:
+      ssi:
+        miw:
+          url: http://managed-identity-wallets.tx.test
+          authorityId: BPNL00000003CRHK
+        oauth:
+          tokenurl: http://centralidp.tx.test/auth/realms/CX-Central/protocol/openid-connect/token
+          client:
+            id: satest02
+      ingresses:
+        - enabled: true
+          hostname: "dataprovider-controlplane.tx.test"
+          endpoints:
+            - default
+            - protocol
+            - management
+          tls:
+            enabled: false
+    dataplane:
+      ingresses:
+        - enabled: true
+          hostname: "dataprovider-dataplane.tx.test"
+          endpoints:
+            - default
+            - public
+          tls:
+            enabled: false
   # -- uncomment the following for persistance
-  # tractusx-connector:
-  #   postgresql:
-  #     primary:
-  #       persistence:
-  #         enabled: true
+    # postgresql:
+    #   primary:
+    #     persistence:
+    #       enabled: true
   # digital-twin-registry:
   #   postgresql:
   #     primary:

--- a/charts/umbrella/values.yaml
+++ b/charts/umbrella/values.yaml
@@ -549,7 +549,7 @@ managed-identity-wallet:
     initialDelaySeconds: 90
   readinessProbe:
     initialDelaySeconds: 90
-  # -- docs: https://managed-identity-wallets.tx.test/ui/swagger-ui/index.html
+  # -- docs: http://managed-identity-wallets.tx.test/ui/swagger-ui/index.html
   ingress:
     enabled: true
     hosts:
@@ -557,14 +557,16 @@ managed-identity-wallet:
         paths:
           - path: "/"
             pathType: "ImplementationSpecific"
-    tls:
-      - secretName: "managed-identity-wallets.tx.test-tls"
-        hosts:
-          - "managed-identity-wallets.tx.test"
+    # uncomment the following lines for tls
+    # tls:
+    #   - secretName: "managed-identity-wallets.tx.test-tls"
+    #     hosts:
+    #       - "managed-identity-wallets.tx.test"
     className: "nginx"
     annotations:
-      cert-manager.io/cluster-issuer: "my-ca-issuer"
-      nginx.ingress.kubernetes.io/cors-allow-origin: https://portal.tx.test
+      # uncomment the following lines for tls
+      # cert-manager.io/cluster-issuer: "my-ca-issuer"
+      nginx.ingress.kubernetes.io/cors-allow-origin: http://portal.tx.test
       nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
       nginx.ingress.kubernetes.io/cors-allow-methods: GET
       nginx.ingress.kubernetes.io/enable-cors: "true"
@@ -582,10 +584,10 @@ dataconsumer:
     controlplane:
       ssi:
         miw:
-          url: https://managed-identity-wallets.tx.test
+          url: http://managed-identity-wallets.tx.test
           authorityId: BPNL00000003CRHK
         oauth:
-          tokenurl: https://centralidp.tx.test/auth/realms/CX-Central/protocol/openid-connect/token
+          tokenurl: http://centralidp.tx.test/auth/realms/CX-Central/protocol/openid-connect/token
           client:
             id: *miw_client
             secretAlias: edc-miw-keycloak-secret
@@ -654,10 +656,10 @@ tx-data-provider:
     controlplane:
       ssi:
         miw:
-          url: https://managed-identity-wallets.tx.test
+          url: http://managed-identity-wallets.tx.test
           authorityId: BPNL00000003CRHK
         oauth:
-          tokenurl: https://centralidp.tx.test/auth/realms/CX-Central/protocol/openid-connect/token
+          tokenurl: http://centralidp.tx.test/auth/realms/CX-Central/protocol/openid-connect/token
           client:
             id: *miw_client
             secretAlias: edc-miw-keycloak-secret


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

- add config in adopter values file to make override of relevant values clearer
- remove disabled components from adopter values file as they defaulting to disabled by now 
- why no tls connection?:
  -  tls.crt from root-secret can't get imported into truststore of the tractusx-connector, at least not automatically: the customCaCerts option exists but that would require to copy the autogenerated tls.crt into the values file
  - when attempting the option with customCaCerts, the flow doesn't e2e due to the miw being unable to verify the jwt signature of the centralidp, even if the tls.crt from the root-secret is imported into the truststore of the miw

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
