### PR TITLE
chore: enable post-upgrade hook and add imagePullPolicy

### DIFF
--- a/charts/tx-data-provider/Chart.yaml
+++ b/charts/tx-data-provider/Chart.yaml
@@ -23,7 +23,7 @@ name: tx-data-provider
 description: A Helm chart for Kubernetes
 
 type: application
-version: 0.0.2
+version: 0.0.3
 appVersion: 0.0.1
 
 dependencies:

--- a/charts/tx-data-provider/templates/post-install-job-upload-testdata.yaml
+++ b/charts/tx-data-provider/templates/post-install-job-upload-testdata.yaml
@@ -39,7 +39,7 @@ metadata:
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
-    "helm.sh/hook": post-install
+    "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "-4"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
@@ -55,6 +55,7 @@ spec:
       containers:
         - name: post-install-job
           image: "python:3.11"
+          imagePullPolicy: "IfNotPresent"
           command:
             - "/bin/sh"
             - "-c"

--- a/charts/tx-data-provider/templates/post-install-vault-setup.yaml
+++ b/charts/tx-data-provider/templates/post-install-vault-setup.yaml
@@ -33,7 +33,7 @@ metadata:
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
-    "helm.sh/hook": post-install
+    "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "-5"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
@@ -49,6 +49,7 @@ spec:
       containers:
         - name: post-install-job
           image: "alpine:3.19"
+          imagePullPolicy: "IfNotPresent"
           command:
             - "/bin/sh"
             - "-c"


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

enable post-upgrade hook and add imagePullPolicy for postinstall jobs of tx-data-provider

post-upgrade hook is needed for dataconsumerTwo

https://github.com/eclipse-tractusx/sig-release/issues/418

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
