### PR TITLE
chore: add dataconsumerTwo, pgadmin4 and improve portal

### DIFF
--- a/charts/umbrella/Chart.yaml
+++ b/charts/umbrella/Chart.yaml
@@ -65,14 +65,20 @@ dependencies:
     repository: https://eclipse-tractusx.github.io/charts/dev
     version: 0.4.0
     condition: managed-identity-wallet.enabled
-    # TX Data Consumer
+    # TX Data Consumer 1
   - name: tx-data-provider
-    alias: dataconsumer
-    version: 0.0.2
+    alias: dataconsumerOne
+    version: 0.0.3
     repository: https://eclipse-tractusx.github.io/charts/dev
-    condition: dataconsumer.enabled
+    condition: dataconsumerOne.enabled
     # TX Data Providers
   - name: tx-data-provider
-    version: 0.0.2
+    version: 0.0.3
     repository: https://eclipse-tractusx.github.io/charts/dev
     condition: tx-data-provider.enabled
+    # TX Data Consumer 2
+  - name: tx-data-provider
+    alias: dataconsumerTwo
+    version: 0.0.3
+    repository: https://eclipse-tractusx.github.io/charts/dev
+    condition: dataconsumerTwo.enabled

--- a/charts/umbrella/Chart.yaml
+++ b/charts/umbrella/Chart.yaml
@@ -28,7 +28,7 @@ sources:
   - https://github.com/eclipse-tractusx/tractus-x-umbrella
 
 type: application
-version: 0.12.1
+version: 0.13.0
 
 # when adding or updating versions of dependencies, also update list under README.md#Install
 dependencies:
@@ -36,7 +36,7 @@ dependencies:
   - condition: portal.enabled
     name: portal
     repository: https://eclipse-tractusx.github.io/charts/dev
-    version: 1.8.0
+    version: 1.8.1
   # cx-iam
   - condition: centralidp.enabled
     name: centralidp

--- a/charts/umbrella/Chart.yaml
+++ b/charts/umbrella/Chart.yaml
@@ -82,3 +82,7 @@ dependencies:
     version: 0.0.3
     repository: https://eclipse-tractusx.github.io/charts/dev
     condition: dataconsumerTwo.enabled
+  - condition: pgadmin4.enabled
+    name: pgadmin4
+    repository: https://helm.runix.net
+    version: 1.25.x

--- a/charts/umbrella/README.md
+++ b/charts/umbrella/README.md
@@ -170,7 +170,7 @@ Select a subset of components which are designed to integrate with each other fo
 
 The currently available components are following:
 
-- [portal](https://github.com/eclipse-tractusx/portal/tree/portal-1.8.0)
+- [portal](https://github.com/eclipse-tractusx/portal/tree/portal-1.8.1)
 - [centralidp](https://github.com/eclipse-tractusx/portal-iam/tree/v2.1.0)
 - [sharedidp](https://github.com/eclipse-tractusx/portal-iam/tree/v2.1.0)
 - [bpndiscovery](https://github.com/eclipse-tractusx/sldt-bpn-discovery/tree/bpndiscovery-0.2.2)

--- a/charts/umbrella/README.md
+++ b/charts/umbrella/README.md
@@ -176,8 +176,9 @@ The currently available components are following:
 - [discoveryfinder](https://github.com/eclipse-tractusx/sldt-discovery-finder/tree/discoveryfinder-0.2.2)
 - [sdfactory](https://github.com/eclipse-tractusx/sd-factory/tree/sdfactory-2.1.12)
 - [managed-identity-wallet](https://github.com/eclipse-tractusx/managed-identity-wallet/tree/v0.4.0)
-- [dataconsumer](https://github.com/eclipse-tractusx/tractus-x-umbrella/tree/main/charts/tx-data-provider) ([tractusx-edc](https://github.com/eclipse-tractusx/tractusx-edc/tree/0.5.3), [vault](https://github.com/hashicorp/vault-helm/tree/v0.20.0))
+- [dataconsumerOne](https://github.com/eclipse-tractusx/tractus-x-umbrella/tree/main/charts/tx-data-provider) ([tractusx-edc](https://github.com/eclipse-tractusx/tractusx-edc/tree/0.5.3), [vault](https://github.com/hashicorp/vault-helm/tree/v0.20.0))
 - [tx-data-provider](https://github.com/eclipse-tractusx/tractus-x-umbrella/tree/main/charts/tx-data-provider) ([tractusx-edc](https://github.com/eclipse-tractusx/tractusx-edc/tree/0.5.3), [digital-twin-registry](https://github.com/eclipse-tractusx/sldt-digital-twin-registry/tree/digital-twin-registry-0.4.5), [vault](https://github.com/hashicorp/vault-helm/tree/v0.20.0), [simple-data-backend](https://github.com/eclipse-tractusx/tractus-x-umbrella/tree/main/charts/simple-data-backend))
+- [dataconsumerTwo](https://github.com/eclipse-tractusx/tractus-x-umbrella/tree/main/charts/tx-data-provider) ([tractusx-edc](https://github.com/eclipse-tractusx/tractusx-edc/tree/0.5.3), [vault](https://github.com/hashicorp/vault-helm/tree/v0.20.0))
 
 > :warning:
 >
@@ -205,10 +206,19 @@ Or choose to install one of the predefined subsets (currently in focus of the **
 
 ```bash
 helm install \
-  --set centralidp.enabled=true,managed-identity-wallet.enabled=true,dataconsumer.enabled=true,tx-data-provider.enabled=true \
+  --set centralidp.enabled=true,managed-identity-wallet.enabled=true,dataconsumerOne.enabled=true,tx-data-provider.enabled=true \
   umbrella tractusx-dev/umbrella \
   --namespace umbrella
 ```
+Optional:
+
+Enable `dataconsumerTwo` at upgrade:
+
+```bash
+helm install \
+  --set centralidp.enabled=true,managed-identity-wallet.enabled=true,dataconsumerOne.enabled=true,tx-data-provider.enabled=true,dataconsumerTwo.enabled=true \
+  umbrella tractusx-dev/umbrella \
+  --namespace umbrella
 
 **Portal**
 
@@ -257,6 +267,19 @@ Or choose to install one of the predefined subsets (currently in focus of the **
 
 ```bash
 helm install -f values-adopter-data-exchange.yaml umbrella . --namespace umbrella
+```
+
+Optional:
+
+Enable `dataconsumerTwo` by setting it true in `values-adopter-data-exchange.yaml` and then executing an upgrade:
+
+```bash
+dataconsumerTwo:
+  enabled: true
+```
+
+```bash
+helm upgrade -f values-adopter-data-exchange.yaml umbrella . --namespace umbrella
 ```
 
 **Portal**

--- a/charts/umbrella/README.md
+++ b/charts/umbrella/README.md
@@ -16,6 +16,7 @@ The chart aims for a completely automated setup of a fully functional network, t
   - [Data exchange](#data-exchange)
   - [Get to know the portal](#get-to-know-the-portal)
 - [Uninstall](#uninstall)
+- [Database Access](#database-access)
 - [Ingresses](#ingresses)
 - [Seeding](#seeding)
 
@@ -366,6 +367,24 @@ helm delete umbrella --namespace umbrella
 >
 > If persistance for one or more components is enabled, the persistent volume claims (PVCs) and connected persistent volumes (PVs) need to be removed manually even if you deleted the release from the cluster.
 >
+
+### Database Access
+
+This chart also contains a pgadmin4 instance for easy access to the deployed Postgres databases which are only available from within the Kubernetes cluster.
+
+pgadmin4 is by default enabled with in the predefined subsets for data exchange and portal.
+
+Address: [pgadmin4.tx.test](http://pgadmin4.tx.test)
+
+Credentials to login:
+
+```
+pgadmin4@txtest.org
+```
+
+```
+tractusxpgdamin4
+```
 
 ### Ingresses
 

--- a/charts/umbrella/values-adopter-data-exchange.yaml
+++ b/charts/umbrella/values-adopter-data-exchange.yaml
@@ -65,7 +65,7 @@ managed-identity-wallet:
   #     persistence:
   #       enabled: true
 
-dataconsumer:
+dataconsumerOne:
   enabled: true
   secrets:
     edc-miw-keycloak-secret: UbfW4CR1xH4OskkovqJ2JzcwnQIrG7oj
@@ -86,7 +86,7 @@ dataconsumer:
           authKey: TEST1
       ingresses:
         - enabled: true
-          hostname: "dataconsumer-controlplane.tx.test"
+          hostname: "dataconsumer-1-controlplane.tx.test"
           endpoints:
             - default
             - protocol
@@ -96,7 +96,7 @@ dataconsumer:
     dataplane:
       ingresses:
         - enabled: true
-          hostname: "dataconsumer-dataplane.tx.test"
+          hostname: "dataconsumer-1-dataplane.tx.test"
           endpoints:
             - default
             - public
@@ -152,3 +152,46 @@ tx-data-provider:
   #     primary:
   #       persistence:
   #         enabled: true
+
+dataconsumerTwo:
+  enabled: false
+  secrets:
+    edc-miw-keycloak-secret: tPwy4exxH1sXBRQouobSA2nNVaaPuwCs
+  tractusx-connector:
+    participant:
+      id: BPNL00000003AVTH
+    controlplane:
+      ssi:
+        miw:
+          url: http://managed-identity-wallets.tx.test
+          authorityId: BPNL00000003CRHK
+        oauth:
+          tokenurl: http://centralidp.tx.test/auth/realms/CX-Central/protocol/openid-connect/token
+          client:
+            id: satest03
+      endpoints:
+        management:
+          authKey: TEST3
+      ingresses:
+        - enabled: true
+          hostname: "dataconsumer-2-controlplane.tx.test"
+          endpoints:
+            - default
+            - protocol
+            - management
+          tls:
+            enabled: false
+    dataplane:
+      ingresses:
+        - enabled: true
+          hostname: "dataconsumer-2-dataplane.tx.test"
+          endpoints:
+            - default
+            - public
+          tls:
+            enabled: false
+    # -- uncomment the following for persistance
+    # postgresql:
+    #   primary:
+    #     persistence:
+    #       enabled: true

--- a/charts/umbrella/values-adopter-data-exchange.yaml
+++ b/charts/umbrella/values-adopter-data-exchange.yaml
@@ -195,3 +195,6 @@ dataconsumerTwo:
     #   primary:
     #     persistence:
     #       enabled: true
+
+pgadmin4:
+  enabled: true

--- a/charts/umbrella/values-adopter-portal.yaml
+++ b/charts/umbrella/values-adopter-portal.yaml
@@ -61,3 +61,6 @@ dataconsumer:
 
 tx-data-provider:
   enabled: false
+
+pgadmin4:
+  enabled: true

--- a/charts/umbrella/values.yaml
+++ b/charts/umbrella/values.yaml
@@ -83,21 +83,69 @@ portal:
         clientId: "sa-cl1-reg-1"
         clientSecret: "YPA1t6BMQtPtaG3fpH8Sa8Ac6KYbPUM7"
     registration:
+      logging:
+        default: "Debug"
+        bpdmLibrary: "Debug"
+        registrationService: "Debug"
       swaggerEnabled: true
     administration:
+      logging:
+        default: "Debug"
+        businessLogic: "Debug"
+        sdfactoryLibrary: "Debug"
+        bpdmLibrary: "Debug"
+        custodianLibrary: "Debug"
       swaggerEnabled: true
     appmarketplace:
+      logging:
+        default: "Debug"
+        offersLibrary: "Debug"
       swaggerEnabled: true
     services:
+      logging:
+        default: "Debug"
+        offersLibrary: "Debug"
       swaggerEnabled: true
     notification:
+      logging:
+        default: "Debug"
       swaggerEnabled: true
+    processesworker:
+      logging:
+        default: "Debug"
+        processesLibrary: "Debug"
+        bpdmLibrary: "Debug"
+        clearinghouseLibrary: "Debug"
+        custodianLibrary: "Debug"
+        sdfactoryLibrary: "Debug"
+        offerProvider: "Debug"
+      bpdm:
+        clientId: "sa-cl7-cx-5"
+        clientSecret: "bWSck103qNJ0jZ1LVtG9mUAlcL7R5RLg"
+      # -- no configuration for clearinghouse because it's an external component
+      # clientId and clientSecret aren't in the centralidp Keycloak
+      # clearinghouse:
+      #   clientId: "clearinghouse-client-id"
+      #   clientSecret: ""
+      custodian:
+        clientId: "sa-cl5-custodian-2"
+        clientSecret: "UIqawwoohsvZ6AZOd1llLhnsUTKMWe4D"
+      sdfactory:
+        issuerBpn: "BPNL00000003CRHK"
+        clientId: "sa-cl8-cx-1"
+        clientSecret: "clbQOPHcVKY9tUUd068vyf8CrsPZ8BgZ"
+      offerprovider:
+        clientId: "sa-cl2-03"
+        clientSecret: "wyNYzSnyu4iGvj17XgLSl0aQxAPjTjmI"
     mailing:
       host: "smtp.tx.test"
       port: "587"
       user: "smtp-user"
       senderEmail: "smtp@tx.test"
       password: ""
+    portalmigrations:
+      logging:
+        default: "Debug"
     provisioning:
       sharedRealm:
         smtpServer:
@@ -564,7 +612,7 @@ managed-identity-wallet:
     #       - "managed-identity-wallets.tx.test"
     className: "nginx"
     annotations:
-      # uncomment the following lines for tls
+      # uncomment the following line for tls
       # cert-manager.io/cluster-issuer: "my-ca-issuer"
       nginx.ingress.kubernetes.io/cors-allow-origin: http://portal.tx.test
       nginx.ingress.kubernetes.io/cors-allow-credentials: "true"

--- a/charts/umbrella/values.yaml
+++ b/charts/umbrella/values.yaml
@@ -833,3 +833,17 @@ dataconsumerTwo:
 
   simple-data-backend:
     enabled: false
+
+pgadmin4:
+  enabled: false
+  env:
+    email: pgadmin4@txtest.org
+    password: tractusxpgdamin4
+  ingress:
+    enabled: true
+    ingressClassName: "nginx"
+    hosts:
+      - host: pgadmin4.tx.test
+        paths:
+        - path: /
+          pathType: Prefix

--- a/charts/umbrella/values.yaml
+++ b/charts/umbrella/values.yaml
@@ -619,14 +619,14 @@ managed-identity-wallet:
       nginx.ingress.kubernetes.io/cors-allow-methods: GET
       nginx.ingress.kubernetes.io/enable-cors: "true"
 
-dataconsumer:
+dataconsumerOne:
   enabled: false
   seedTestdata: false
-  nameOverride: dataconsumer
+  nameOverride: dataconsumer-1
   secrets:
     edc-miw-keycloak-secret: changeme  # TODO switch to existing user
   tractusx-connector:
-    nameOverride: dataconsumer-edc
+    nameOverride: dataconsumer-1-edc
     participant:
       id: BPNL000000000000
     controlplane:
@@ -644,7 +644,7 @@ dataconsumer:
           authKey: TEST1
       ingresses:
         - enabled: true
-          hostname: "dataconsumer-controlplane.tx.test"
+          hostname: "dataconsumer-1-controlplane.tx.test"
           endpoints:
             - default
             - protocol
@@ -655,7 +655,7 @@ dataconsumer:
     dataplane:
       ingresses:
         - enabled: true
-          hostname: "dataconsumer-dataplane.tx.test"
+          hostname: "dataconsumer-1-dataplane.tx.test"
           endpoints:
             - default
             - public
@@ -663,19 +663,19 @@ dataconsumer:
           tls:
             enabled: false
     postgresql:
-      nameOverride: dataconsumer-db
-      jdbcUrl: "jdbc:postgresql://{{ .Release.Name }}-dataconsumer-db:5432/edc"
+      nameOverride: dataconsumer-1-db
+      jdbcUrl: "jdbc:postgresql://{{ .Release.Name }}-dataconsumer-1-db:5432/edc"
     vault:
       hashicorp:
-        url: http://edc-dataconsumer-vault:8200
+        url: http://edc-dataconsumer-1-vault:8200
       secretNames:
         transferProxyTokenSignerPrivateKey: tokenSignerPrivateKey
         transferProxyTokenSignerPublicKey: tokenSignerPublicKey
         transferProxyTokenEncryptionAesKey: tokenEncryptionAesKey
 
   vault:
-    nameOverride: edc-dataconsumer-vault
-    fullnameOverride: edc-dataconsumer-vault
+    nameOverride: edc-dataconsumer-1-vault
+    fullnameOverride: edc-dataconsumer-1-vault
     enabled: true
     server:
       postStart: []
@@ -766,3 +766,70 @@ tx-data-provider:
     nameOverride: dataprovider-submodelserver
     ingress:
       enabled: false
+
+dataconsumerTwo:
+  enabled: false
+  seedTestdata: false
+  nameOverride: dataconsumer-2
+  secrets:
+    edc-miw-keycloak-secret: changeme  # TODO switch to existing user
+  tractusx-connector:
+    nameOverride: dataconsumer-2-edc
+    participant:
+      id: BPNL000000000000
+    controlplane:
+      ssi:
+        miw:
+          url: http://managed-identity-wallets.tx.test
+          authorityId: BPNL00000003CRHK
+        oauth:
+          tokenurl: http://centralidp.tx.test/auth/realms/CX-Central/protocol/openid-connect/token
+          client:
+            id: *miw_client
+            secretAlias: edc-miw-keycloak-secret
+      endpoints:
+        management:
+          authKey: TEST1
+      ingresses:
+        - enabled: true
+          hostname: "dataconsumer-2-controlplane.tx.test"
+          endpoints:
+            - default
+            - protocol
+            - management
+          className: "nginx"
+          tls:
+            enabled: false
+    dataplane:
+      ingresses:
+        - enabled: true
+          hostname: "dataconsumer-2-dataplane.tx.test"
+          endpoints:
+            - default
+            - public
+          className: "nginx"
+          tls:
+            enabled: false
+    postgresql:
+      nameOverride: dataconsumer-2-db
+      jdbcUrl: "jdbc:postgresql://{{ .Release.Name }}-dataconsumer-2-db:5432/edc"
+    vault:
+      hashicorp:
+        url: http://edc-dataconsumer-2-vault:8200
+      secretNames:
+        transferProxyTokenSignerPrivateKey: tokenSignerPrivateKey
+        transferProxyTokenSignerPublicKey: tokenSignerPublicKey
+        transferProxyTokenEncryptionAesKey: tokenEncryptionAesKey
+
+  vault:
+    nameOverride: edc-dataconsumer-2-vault
+    fullnameOverride: edc-dataconsumer-2-vault
+    enabled: true
+    server:
+      postStart: []
+
+  digital-twin-registry:
+    enabled: false
+
+  simple-data-backend:
+    enabled: false


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

- add dataconsumerTwo: disabled by default, to be installed at upgrade of data exchange subset
required https://github.com/eclipse-tractusx/tractus-x-umbrella/pull/81
- add pgadmin4 instance for database access
- change to portal 1.8.1 and complete config

https://github.com/eclipse-tractusx/sig-release/issues/418

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
