### PR TITLE
fix(tx-data-provider): do not seed testdata again on upgrade

### DIFF
--- a/charts/tx-data-provider/Chart.yaml
+++ b/charts/tx-data-provider/Chart.yaml
@@ -23,7 +23,7 @@ name: tx-data-provider
 description: A Helm chart for Kubernetes
 
 type: application
-version: 0.0.3
+version: 0.0.4
 appVersion: 0.0.1
 
 dependencies:

--- a/charts/tx-data-provider/templates/post-install-job-upload-testdata.yaml
+++ b/charts/tx-data-provider/templates/post-install-job-upload-testdata.yaml
@@ -39,7 +39,7 @@ metadata:
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
-    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook": post-install
     "helm.sh/hook-weight": "-4"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:

--- a/charts/umbrella/Chart.yaml
+++ b/charts/umbrella/Chart.yaml
@@ -28,7 +28,7 @@ sources:
   - https://github.com/eclipse-tractusx/tractus-x-umbrella
 
 type: application
-version: 0.14.0
+version: 0.14.1
 
 # when adding or updating versions of dependencies, also update list under README.md#Install
 dependencies:

--- a/hack/helm-dependencies.bash
+++ b/hack/helm-dependencies.bash
@@ -5,6 +5,7 @@ if ! helm repo list ; then
   echo "Need to add repos"
   helm repo add tractusx https://eclipse-tractusx.github.io/charts/dev
   helm repo add hashicorp https://helm.releases.hashicorp.com
+  helm repo add runix https://helm.runix.net
 fi
 
 # This hack script will download all chart/umbrella dependency charts.


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

fix: do not seed testdata again on upgrade

introduced with https://github.com/eclipse-tractusx/tractus-x-umbrella/pull/81

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
