### PR TITLE
fix: add runix helm repo to the dependency hack script

### DIFF
--- a/charts/umbrella/Chart.yaml
+++ b/charts/umbrella/Chart.yaml
@@ -28,7 +28,7 @@ sources:
   - https://github.com/eclipse-tractusx/tractus-x-umbrella
 
 type: application
-version: 0.14.0
+version: 0.14.1
 
 # when adding or updating versions of dependencies, also update list under README.md#Install
 dependencies:

--- a/hack/helm-dependencies.bash
+++ b/hack/helm-dependencies.bash
@@ -5,6 +5,7 @@ if ! helm repo list ; then
   echo "Need to add repos"
   helm repo add tractusx https://eclipse-tractusx.github.io/charts/dev
   helm repo add hashicorp https://helm.releases.hashicorp.com
+  helm repo add runix https://helm.runix.net
 fi
 
 # This hack script will download all chart/umbrella dependency charts.


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

Trying to fix the helm dependency hack script that is currently failing [here](https://github.com/eclipse-tractusx/tractus-x-umbrella/actions/runs/9059263005/job/24889079879?pr=84#step:11:19).

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
