### PR TITLE
feat: hardcode postgres passwords

### DIFF
--- a/charts/umbrella/Chart.yaml
+++ b/charts/umbrella/Chart.yaml
@@ -28,7 +28,7 @@ sources:
   - https://github.com/eclipse-tractusx/tractus-x-umbrella
 
 type: application
-version: 0.15.3
+version: 0.15.4
 
 # when adding or updating versions of dependencies, also update list under README.md#Install
 dependencies:

--- a/charts/umbrella/README.md
+++ b/charts/umbrella/README.md
@@ -449,7 +449,7 @@ pgadmin4 is by default enabled with in the predefined subsets for data exchange 
 
 Address: [pgadmin4.tx.test](http://pgadmin4.tx.test)
 
-Credentials to login:
+Credentials to login into pgadmin4:
 
 ```
 pgadmin4@txtest.org
@@ -457,6 +457,120 @@ pgadmin4@txtest.org
 
 ```
 tractusxpgdamin4
+```
+
+**The database server connections need to be added manually to pgadmin4.**
+
+Default username for all connections:
+
+```
+postgres
+```
+
+Default user for all connections:
+
+```
+5432
+```
+
+In the following some of the available connections:
+
+- portal
+
+Host:
+
+```
+portal-backend-postgresql
+```
+
+Password:
+
+```
+dbpasswordportal
+```
+
+- centralidp
+
+Host:
+
+```
+umbrella-centralidp-postgresql
+```
+
+Password:
+
+```
+dbpasswordcentralidp
+```
+
+- sharedidp
+
+Host:
+
+```
+umbrella-sharedidp-postgresql
+```
+
+Password:
+
+```
+dbpasswordsharedidp
+```
+
+- miw
+
+Host:
+
+```
+umbrella-miw-postgres
+```
+
+Password:
+
+```
+dbpasswordmiw
+```
+
+- dataprovider
+
+Host:
+
+```
+umbrella-dataprovider-db
+```
+
+Password:
+
+```
+dbpasswordtxdataprovider
+```
+
+- dataconsumer-1
+
+Host:
+
+```
+umbrella-dataconsumer-1-db
+```
+
+Password:
+
+```
+dbpassworddataconsumerone
+```
+
+- dataconsumer-2
+
+Host:
+
+```
+umbrella-dataconsumer-2-db
+```
+
+Password:
+
+```
+dbpassworddataconsumertwo
 ```
 
 ### Ingresses

--- a/charts/umbrella/values.yaml
+++ b/charts/umbrella/values.yaml
@@ -224,8 +224,6 @@ centralidp:
       primary:
         persistence:
           enabled: false
-    externalDatabase:
-      password: "dbpasswordcentralidp"
     proxy: edge
     initContainers:
       - name: realm-import
@@ -348,8 +346,6 @@ sharedidp:
       primary:
         persistence:
           enabled: false
-    externalDatabase:
-      password: "dbpasswordsharedidp"
     proxy: edge
     initContainers:
       - name: realm-import
@@ -490,7 +486,7 @@ bpndiscovery:
         size: 8Gi
     auth:
       password: "dbpasswordbpndiscovery"
-      posrgresPassword: "dbpasswordbpndiscovery"
+      postgresPassword: "dbpasswordbpndiscovery"
 
 discoveryfinder:
   enabled: false
@@ -535,7 +531,7 @@ discoveryfinder:
         size: 8Gi
     auth:
       password: "dbpassworddiscoveryfinder"
-      posrgresPassword: "dbpassworddiscoveryfinder"
+      postgresPassword: "dbpassworddiscoveryfinder"
 
 sdfactory:
   enabled: false
@@ -716,6 +712,9 @@ dataconsumerOne:
     postgresql:
       nameOverride: dataconsumer-1-db
       jdbcUrl: "jdbc:postgresql://{{ .Release.Name }}-dataconsumer-1-db:5432/edc"
+      auth:
+        password: "dbpassworddataconsumerone"
+        postgresPassword: "dbpassworddataconsumerone"
     vault:
       hashicorp:
         url: http://edc-dataconsumer-1-vault:8200
@@ -811,7 +810,7 @@ tx-data-provider:
     postgresql:
       nameOverride: dataprovider-dtr-db
       auth:
-        password: "dtrdataproviderpw"
+        password: "dbpassworddtrdataprovider"
         existingSecret: dataprovider-secret-dtr-postgres-init
     registry:
       host: dataprovider-dtr.test

--- a/charts/umbrella/values.yaml
+++ b/charts/umbrella/values.yaml
@@ -21,9 +21,13 @@ portal:
   enabled: false
   replicaCount: 1
   postgresql:
-    postgresql:
     nameOverride: "portal-backend-postgresql"
     architecture: standalone
+    auth:
+      password: "dbpasswordportal"
+      portalPassword: "dbpasswordportal"
+      replicationPassword: "dbpasswordportal"
+      provisioningPassword: "dbpasswordportal"
     primary:
       persistence:
         enabled: false

--- a/charts/umbrella/values.yaml
+++ b/charts/umbrella/values.yaml
@@ -638,6 +638,8 @@ managed-identity-wallet:
         size: 1Gi
     auth:
       password: "dbpasswordmiw"
+      enablePostgresUser: true
+      postgresPassword: "dbpasswordmiw"
   keycloak:
     enabled: false
   livenessProbe:

--- a/charts/umbrella/values.yaml
+++ b/charts/umbrella/values.yaml
@@ -788,6 +788,9 @@ tx-data-provider:
     postgresql:
       nameOverride: dataprovider-db
       jdbcUrl: "jdbc:postgresql://{{ .Release.Name }}-dataprovider-db:5432/edc"
+      auth:
+        password: "dbpasswordtxdataprovider"
+        postgresPassword: "dbpasswordtxdataprovider"
     vault:
       hashicorp:
         url: http://edc-dataprovider-vault:8200

--- a/charts/umbrella/values.yaml
+++ b/charts/umbrella/values.yaml
@@ -889,6 +889,9 @@ dataconsumerTwo:
     postgresql:
       nameOverride: dataconsumer-2-db
       jdbcUrl: "jdbc:postgresql://{{ .Release.Name }}-dataconsumer-2-db:5432/edc"
+      auth:
+        password: "dbpassworddataconsumertwo"
+        postgresPassword: "dbpassworddataconsumertwo"
     vault:
       hashicorp:
         url: http://edc-dataconsumer-2-vault:8200

--- a/charts/umbrella/values.yaml
+++ b/charts/umbrella/values.yaml
@@ -224,6 +224,8 @@ centralidp:
       primary:
         persistence:
           enabled: false
+    externalDatabase:
+      password: "dbpasswordcentralidp"
     proxy: edge
     initContainers:
       - name: realm-import
@@ -322,6 +324,12 @@ centralidp:
         nginx.ingress.kubernetes.io/use-regex: "true"
       tls: true
   secrets:
+    postgresql:
+      auth:
+        existingSecret:
+          postgrespassword: "dbpasswordcentralidp"
+          password: "dbpasswordcentralidp"
+          replicationPassword: "dbpasswordcentralidp"
     auth:
       existingSecret:
         # -- Password for the admin username 'admin'. Secret-key 'admin-password'.
@@ -340,6 +348,8 @@ sharedidp:
       primary:
         persistence:
           enabled: false
+    externalDatabase:
+      password: "dbpasswordsharedidp"
     proxy: edge
     initContainers:
       - name: realm-import
@@ -444,6 +454,12 @@ sharedidp:
         nginx.ingress.kubernetes.io/use-regex: "true"
       tls: true
   secrets:
+    postgresql:
+      auth:
+        existingSecret:
+          postgrespassword: "dbpasswordsharedidp"
+          password: "dbpasswordsharedidp"
+          replicationPassword: "dbpasswordsharedidp"
     auth:
       existingSecret:
         # -- Password for the admin username 'admin'. Secret-key 'admin-password'.

--- a/charts/umbrella/values.yaml
+++ b/charts/umbrella/values.yaml
@@ -640,6 +640,8 @@ managed-identity-wallet:
       persistence:
         enabled: false
         size: 1Gi
+    auth:
+      password: "dbpasswordmiw"
   keycloak:
     enabled: false
   livenessProbe:

--- a/charts/umbrella/values.yaml
+++ b/charts/umbrella/values.yaml
@@ -488,6 +488,9 @@ bpndiscovery:
       persistence:
         enabled: false
         size: 8Gi
+    auth:
+      password: "dbpasswordbpndiscovery"
+      posrgresPassword: "dbpasswordbpndiscovery"
 
 discoveryfinder:
   enabled: false
@@ -530,6 +533,9 @@ discoveryfinder:
       persistence:
         enabled: false
         size: 8Gi
+    auth:
+      password: "dbpassworddiscoveryfinder"
+      posrgresPassword: "dbpassworddiscoveryfinder"
 
 sdfactory:
   enabled: false


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

We are hardcoding the postgresql database passwords for the postgres and custom users as well wherever possible to help users with authentication and pgadmin4 usage. The password pattern will be `dbpassword<productname>`.

- [x] Portal
- [x] Central IDP
- [x] Shared IDP
- [x] BPN Discovery
- [x] Discovery Finder
- [x] MiW
- [x] tx-data-provider
- [x] data cunsumer one
- [x] data cunsumer two

I'll update the description with every modified component.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
