### PR TITLE
Update  versions for discoveryfinder, bpndiscovery, semantic-hub and dtr

### DIFF
--- a/charts/tx-data-provider/Chart.yaml
+++ b/charts/tx-data-provider/Chart.yaml
@@ -28,7 +28,7 @@ appVersion: 0.0.1
 
 dependencies:
   - name: digital-twin-registry
-    version: 0.4.5
+    version: 0.4.11
     repository: https://eclipse-tractusx.github.io/charts/dev
     condition: digital-twin-registry.enabled
   - name: simple-data-backend

--- a/charts/umbrella/Chart.yaml
+++ b/charts/umbrella/Chart.yaml
@@ -50,12 +50,12 @@ dependencies:
   - condition: discoveryfinder.enabled
     name: discoveryfinder
     repository: https://eclipse-tractusx.github.io/charts/dev
-    version: 0.2.2
+    version: 0.2.6
     # bpn-discovery
   - condition: bpndiscovery.enabled
     name: bpndiscovery
     repository: https://eclipse-tractusx.github.io/charts/dev
-    version: 0.2.2
+    version: 0.2.6
     # sd-factory
   - condition: selfdescription.enabled
     name: sdfactory
@@ -71,7 +71,7 @@ dependencies:
   - condition: semantic-hub.enabled
     name: semantic-hub
     repository: https://eclipse-tractusx.github.io/charts/dev
-    version: 0.2.2
+    version: 0.2.3
     # TX Data Consumer 1
   - name: tx-data-provider
     alias: dataconsumerOne


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
Update versions to 24.05 Release:
discoveryfinder and bpndiscovery: 0.2.6
semantic-hub: 0.2.3
digital-twin-registry: 0.4.11

<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
