### PR TITLE
chore(helm-test): determine target branch based on pr base

### DIFF
--- a/.github/workflows/helm-checks.yaml
+++ b/.github/workflows/helm-checks.yaml
@@ -75,15 +75,15 @@ jobs:
       id: set-target-branch
       run: |
         if [ -n "${{ github.event.pull_request.base.ref }}" ]; then
-          echo "traget-branch=${{ github.event.pull_request.base.ref }}" >> $GITHUB_ENV
+          echo "target-branch=${{ github.event.pull_request.base.ref }}" >> $GITHUB_ENV
         else
-          echo "traget-branch=${{ github.event.repository.default_branch }}" >> $GITHUB_ENV
+          echo "target-branch=${{ github.event.repository.default_branch }}" >> $GITHUB_ENV
         fi
 
     - name: Run chart-testing (list-changed)
       id: list-changed
       run: |
-        changed=$(ct list-changed --target-branch ${{ steps.set-target-branch.outputs.traget-branch }})
+        changed=$(ct list-changed --target-branch ${{ steps.set-target-branch.outputs.target-branch }})
         if [[ -n "$changed" ]]; then
           echo "changed=true" >> $GITHUB_OUTPUT
         fi
@@ -150,26 +150,26 @@ jobs:
       id: set-target-branch
       run: |
         if [ -n "${{ github.event.pull_request.base.ref }}" ]; then
-          echo "traget-branch=${{ github.event.pull_request.base.ref }}" >> $GITHUB_ENV
+          echo "target-branch=${{ github.event.pull_request.base.ref }}" >> $GITHUB_ENV
         else
-          echo "traget-branch=${{ github.event.repository.default_branch }}" >> $GITHUB_ENV
+          echo "target-branch=${{ github.event.repository.default_branch }}" >> $GITHUB_ENV
         fi
 
     - name: Set up chart-testing
       uses: helm/chart-testing-action@v2.6.1
 
     - name: Lint chart
-      run: ct lint --validate-maintainers=false --target-branch ${{ steps.set-target-branch.outputs.traget-branch }}
+      run: ct lint --validate-maintainers=false --target-branch ${{ steps.set-target-branch.outputs.target-branch }}
     
     - name: Download chart dependencies (recursive)
       shell: bash
       run: hack/helm-dependencies.bash
 
     - name: Install chart and run tests (simple-data-backend)
-      run: ct install --charts charts/simple-data-backend --target-branch ${{ steps.set-target-branch.outputs.traget-branch }} --helm-extra-set-args "--set image.repository=kind-registry:5000/simple-data-backend --set image.tag=testing"
+      run: ct install --charts charts/simple-data-backend --target-branch ${{ steps.set-target-branch.outputs.target-branch }} --helm-extra-set-args "--set image.repository=kind-registry:5000/simple-data-backend --set image.tag=testing"
 
     - name: Install chart and run tests (tx-data-provider)
-      run: ct install --charts charts/tx-data-provider --target-branch ${{ steps.set-target-branch.outputs.traget-branch }}
+      run: ct install --charts charts/tx-data-provider --target-branch ${{ steps.set-target-branch.outputs.target-branch }}
 
     - name: Install chart for shared services (umbrella)
       run: |

--- a/.github/workflows/helm-checks.yaml
+++ b/.github/workflows/helm-checks.yaml
@@ -75,9 +75,9 @@ jobs:
       id: set-target-branch
       run: |
         if [ -n "${{ github.event.pull_request.base.ref }}" ]; then
-          echo "target-branch=${{ github.event.pull_request.base.ref }}" >> $GITHUB_ENV
+          echo "target-branch=${{ github.event.pull_request.base.ref }}" >> "$GITHUB_OUTPUT"
         else
-          echo "target-branch=${{ github.event.repository.default_branch }}" >> $GITHUB_ENV
+          echo "target-branch=${{ github.event.repository.default_branch }}" >> "$GITHUB_OUTPUT"
         fi
 
     - name: Run chart-testing (list-changed)
@@ -150,9 +150,9 @@ jobs:
       id: set-target-branch
       run: |
         if [ -n "${{ github.event.pull_request.base.ref }}" ]; then
-          echo "target-branch=${{ github.event.pull_request.base.ref }}" >> $GITHUB_ENV
+          echo "target-branch=${{ github.event.pull_request.base.ref }}" >> "$GITHUB_OUTPUT"
         else
-          echo "target-branch=${{ github.event.repository.default_branch }}" >> $GITHUB_ENV
+          echo "target-branch=${{ github.event.repository.default_branch }}" >> "$GITHUB_OUTPUT"
         fi
 
     - name: Set up chart-testing

--- a/.github/workflows/helm-checks.yaml
+++ b/.github/workflows/helm-checks.yaml
@@ -71,10 +71,19 @@ jobs:
     - name: Set up chart-testing
       uses: helm/chart-testing-action@v2.6.1
 
+    - name: Set target branch
+      id: set-target-branch
+      run: |
+        if [ -n "${{ github.event.pull_request.base.ref }}" ]; then
+          echo "traget-branch=${{ github.event.pull_request.base.ref }}" >> $GITHUB_ENV
+        else
+          echo "traget-branch=${{ github.event.repository.default_branch }}" >> $GITHUB_ENV
+        fi
+
     - name: Run chart-testing (list-changed)
       id: list-changed
       run: |
-        changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
+        changed=$(ct list-changed --target-branch ${{ steps.set-target-branch.outputs.traget-branch }})
         if [[ -n "$changed" ]]; then
           echo "changed=true" >> $GITHUB_OUTPUT
         fi
@@ -137,21 +146,30 @@ jobs:
         python-version: '3.10'
         check-latest: true
 
+    - name: Set target branch
+      id: set-target-branch
+      run: |
+        if [ -n "${{ github.event.pull_request.base.ref }}" ]; then
+          echo "traget-branch=${{ github.event.pull_request.base.ref }}" >> $GITHUB_ENV
+        else
+          echo "traget-branch=${{ github.event.repository.default_branch }}" >> $GITHUB_ENV
+        fi
+
     - name: Set up chart-testing
       uses: helm/chart-testing-action@v2.6.1
 
     - name: Lint chart
-      run: ct lint --validate-maintainers=false --target-branch ${{ github.event.repository.default_branch }}
+      run: ct lint --validate-maintainers=false --target-branch ${{ steps.set-target-branch.outputs.traget-branch }}
     
     - name: Download chart dependencies (recursive)
       shell: bash
       run: hack/helm-dependencies.bash
 
     - name: Install chart and run tests (simple-data-backend)
-      run: ct install --charts charts/simple-data-backend --target-branch ${{ github.event.repository.default_branch }} --helm-extra-set-args "--set image.repository=kind-registry:5000/simple-data-backend --set image.tag=testing"
+      run: ct install --charts charts/simple-data-backend --target-branch ${{ steps.set-target-branch.outputs.traget-branch }} --helm-extra-set-args "--set image.repository=kind-registry:5000/simple-data-backend --set image.tag=testing"
 
     - name: Install chart and run tests (tx-data-provider)
-      run: ct install --charts charts/tx-data-provider --target-branch ${{ github.event.repository.default_branch }}
+      run: ct install --charts charts/tx-data-provider --target-branch ${{ steps.set-target-branch.outputs.traget-branch }}
 
     - name: Install chart for shared services (umbrella)
       run: |

--- a/charts/umbrella/Chart.yaml
+++ b/charts/umbrella/Chart.yaml
@@ -28,7 +28,7 @@ sources:
   - https://github.com/eclipse-tractusx/tractus-x-umbrella
 
 type: application
-version: 0.16.0
+version: 0.16.1
 
 # when adding or updating versions of dependencies, also update list under README.md#Install
 # change

--- a/charts/umbrella/Chart.yaml
+++ b/charts/umbrella/Chart.yaml
@@ -31,6 +31,7 @@ type: application
 version: 0.16.0
 
 # when adding or updating versions of dependencies, also update list under README.md#Install
+# change
 dependencies:
   # portal
   - condition: portal.enabled

--- a/charts/umbrella/Chart.yaml
+++ b/charts/umbrella/Chart.yaml
@@ -28,10 +28,9 @@ sources:
   - https://github.com/eclipse-tractusx/tractus-x-umbrella
 
 type: application
-version: 0.16.1
+version: 0.16.0
 
 # when adding or updating versions of dependencies, also update list under README.md#Install
-# change
 dependencies:
   # portal
   - condition: portal.enabled


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

- enable chart testing workflow to determine target branch based on pull request base

necessary because we're enabling the upgrade to R24.05 in another branch than main and the missing enabling blocks the review of https://github.com/eclipse-tractusx/tractus-x-umbrella/pull/106

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
