### PR TITLE
feat: add BPDM chart to umbrella chart

### DIFF
--- a/.github/workflows/helm-checks.yaml
+++ b/.github/workflows/helm-checks.yaml
@@ -163,6 +163,11 @@ jobs:
         helm install umbrella charts/umbrella -f charts/values-test-data-exchange.yaml -f charts/values-test-iam-init-container.yaml --namespace data-exchange --create-namespace --debug --timeout 10m
         helm uninstall umbrella --namespace data-exchange
 
+    - name: Install chart for bpdm (umbrella)
+      run: |
+        helm install umbrella charts/umbrella -f charts/values-test-bpdm.yaml --namespace bpdm --create-namespace --debug --timeout 10m
+        helm uninstall umbrella --namespace bpdm
+
     ## Skip upgrade for now until a working chart is released
     #- name: Run helm upgrade
     #  run: |

--- a/charts/umbrella/Chart.yaml
+++ b/charts/umbrella/Chart.yaml
@@ -28,7 +28,7 @@ sources:
   - https://github.com/eclipse-tractusx/tractus-x-umbrella
 
 type: application
-version: 0.17.0
+version: 0.18.0
 
 # when adding or updating versions of dependencies, also update list under README.md#Install
 dependencies:
@@ -94,3 +94,8 @@ dependencies:
     name: pgadmin4
     repository: https://helm.runix.net
     version: 1.25.x
+    # business partner management and golden record service
+  - condition: bpdm.enabled
+    name: bpdm
+    repository: https://eclipse-tractusx.github.io/charts/dev
+    version: 5.0.3

--- a/charts/umbrella/README.md
+++ b/charts/umbrella/README.md
@@ -123,6 +123,7 @@ If you still face DNS issues, add the hosts to your /etc/hosts file:
 192.168.49.2    dataprovider-dataplane.tx.test
 192.168.49.2    dataconsumer-2-dataplane.tx.test
 192.168.49.2    dataconsumer-2-controlplane.tx.test
+192.168.49.2    business-partners.tx.test
 ```
 
 **Additional network setup for Mac**
@@ -148,6 +149,7 @@ For Windows edit the hosts file under `C:\Windows\System32\drivers\etc\hosts`:
 192.168.49.2    dataprovider-dataplane.tx.test
 192.168.49.2    dataconsumer-2-dataplane.tx.test
 192.168.49.2    dataconsumer-2-controlplane.tx.test
+192.168.49.2    business-partners.tx.test
 ```
 
 ### Install
@@ -167,6 +169,7 @@ The currently available components are following:
 - [dataconsumerOne](https://github.com/eclipse-tractusx/tractus-x-umbrella/tree/main/charts/tx-data-provider) ([tractusx-edc](https://github.com/eclipse-tractusx/tractusx-edc/tree/0.5.3), [vault](https://github.com/hashicorp/vault-helm/tree/v0.20.0))
 - [tx-data-provider](https://github.com/eclipse-tractusx/tractus-x-umbrella/tree/main/charts/tx-data-provider) ([tractusx-edc](https://github.com/eclipse-tractusx/tractusx-edc/tree/0.5.3), [digital-twin-registry](https://github.com/eclipse-tractusx/sldt-digital-twin-registry/tree/digital-twin-registry-0.4.5), [vault](https://github.com/hashicorp/vault-helm/tree/v0.20.0), [simple-data-backend](https://github.com/eclipse-tractusx/tractus-x-umbrella/tree/main/charts/simple-data-backend))
 - [dataconsumerTwo](https://github.com/eclipse-tractusx/tractus-x-umbrella/tree/main/charts/tx-data-provider) ([tractusx-edc](https://github.com/eclipse-tractusx/tractusx-edc/tree/0.5.3), [vault](https://github.com/hashicorp/vault-helm/tree/v0.20.0))
+- [bpdm](https://github.com/eclipse-tractusx/bpdm/tree/release/6.0.x)
 
 > :warning: **Note**
 >
@@ -239,6 +242,15 @@ helm install \
 ```bash
 helm install \
   --set portal.enabled=true,centralidp.enabled=true,sharedidp.enabled=true \
+  umbrella tractusx-dev/umbrella \
+  --namespace umbrella \
+  --create-namespace
+```
+
+**BPDM Subset**
+```bash
+helm install \
+  --set bpdm.enabled=true,centralidp.enabled=true \
   umbrella tractusx-dev/umbrella \
   --namespace umbrella \
   --create-namespace
@@ -417,6 +429,9 @@ Currently enabled ingresses:
 - http://dataconsumer-2-controlplane.tx.test
 - http://dataconsumer-2-dataplane.tx.test
 - http://pgadmin4.tx.test
+- http://business-partners.tx.test/pool
+- http://business-partners.tx.test/companies/test-company
+- http://business-partners.tx.test/orchestrator
 
 ### Database Access
 
@@ -549,6 +564,21 @@ Password:
 ```
 dbpassworddataconsumertwo
 ```
+
+- bpdm
+
+Host:
+
+```
+umbrella-bpdm-postgres
+```
+
+Password:
+
+```
+dbpasswordbpdm
+```
+
 ### Keycloak Admin Console
 
 Access to admin consoles:

--- a/charts/umbrella/values.yaml
+++ b/charts/umbrella/values.yaml
@@ -126,8 +126,8 @@ portal:
         sdfactoryLibrary: "Debug"
         offerProvider: "Debug"
       bpdm:
-        clientId: "sa-cl7-cx-5"
-        clientSecret: "bWSck103qNJ0jZ1LVtG9mUAlcL7R5RLg"
+        clientId: &bpdmAdminClientId "sa-cl7-cx-5"
+        clientSecret: &bpdmAdminClientSecret "bWSck103qNJ0jZ1LVtG9mUAlcL7R5RLg"
       # -- no configuration for clearinghouse because it's an external component
       # clientId and clientSecret aren't in the centralidp Keycloak
       # clearinghouse:
@@ -971,3 +971,215 @@ pgadmin4:
         paths:
         - path: /
           pathType: Prefix
+
+# Set up services for a business partner pool, golden record process
+# and a gate with which the Portal and the users can share business partner data
+bpdm:
+  enabled: false
+
+  postgres:
+    # We use the default name for BPDM postgres
+    fullnameOverride:
+    nameOverride: bpdm-postgres
+    auth:
+      # BPDM can't handle random initial passwords at the moment
+      # so need to set a fixed one here and use it in the app configs later
+      password: &bpdmPostgresPassword "dbpasswordbpdm"
+      postgresPassword: *bpdmPostgresPassword
+    architecture: standalone
+    primary:
+      persistence:
+        enabled: false
+
+  keycloak:
+    # We use Central-IDP as authentication server
+    enabled: false
+
+  # Set up a Gate that acts as the Portal's Gate
+  bpdm-gate:
+    postgres:
+      # App uses BPDM postgres default name to find connection to the Postgres
+      fullnameOverride:
+      nameOverride: bpdm-postgres
+    ingress:
+      enabled: true
+      annotations:
+        nginx.ingress.kubernetes.io/rewrite-target: "/$2"
+        nginx.ingress.kubernetes.io/use-regex: "true"
+        nginx.ingress.kubernetes.io/x-forwarded-prefix: "/companies/test-company"
+      # The Portal expects its Gate on that specific url path so we provide it here through ingress
+      hosts:
+        - host: "business-partners.tx.test"
+          paths:
+            - path: "/companies/test-company(/|$)(.*)"
+              pathType: "ImplementationSpecific"
+    applicationConfig:
+      server:
+        # App should take the x-forward-header-prefix into account for Swagger-UI and redirects to work correctly
+        forward-headers-strategy: "FRAMEWORK"
+      bpdm:
+        bpn:
+          # This Gate has no owner restriction as other companies can write into the Gate under their own tenant
+          owner-bpn-l:
+        tasks:
+          creation:
+            fromSharingMember:
+              # Portal needs to set uploaded business partner data as ready to be shared by itself (disables setting it automatically as ready)
+              starts-as-ready: false
+        security:
+          # App's API is authenticated over Central-IDP
+          auth-server-url: "http://centralidp.tx.test/auth"
+          realm: "CX-Central"
+          # Is Central-IDPs name for the Gate client
+          # The Gate will use that name to check for existing client permissions here
+          client-id: "Cl16-CX-BPDMGate"
+          # Rename default permission names to be compatible with the configuration from the Central-IDP
+          permissions:
+            readInputPartner: view_company_data
+            writeInputPartner: update_company_data
+            readOutputPartner: view_shared_data
+            readInputChangelog: view_company_data
+            readOutputChangelog: view_shared_data
+            readSharingState: view_company_data
+            writeSharingState: update_company_data
+            read_stats: view_company_data
+        # The Gate needs to connect to the Pool and Orchestrator to realize the Golden Record Process
+        # Setup client connection for both here (where to connect and the authentication)
+        # By default the Gate assumes that the authentication server of the Pool and Orchestrator are the same as its own
+        # We will reuse the general BPDM admin technical user to establish connection between the services
+        client:
+          pool:
+            registration:
+              client-id: *bpdmAdminClientId
+          orchestrator:
+            registration:
+              client-id: *bpdmAdminClientId
+    applicationSecrets:
+      spring:
+        datasource:
+          # Set the password of the postgres BPDM user here (Currently, BPDM can't deal with random initial passwords)
+          password: *bpdmPostgresPassword
+      bpdm:
+        client:
+          orchestrator:
+            registration:
+              client-secret: *bpdmAdminClientSecret
+          pool:
+            registration:
+              client-secret: *bpdmAdminClientSecret
+
+  # Configures the central business partner Pool
+  bpdm-pool:
+    postgres:
+      # App uses BPDM postgres default name to find connection to the Postgres
+      fullnameOverride:
+      nameOverride: bpdm-postgres
+    ingress:
+      enabled: true
+      annotations:
+        nginx.ingress.kubernetes.io/rewrite-target: "/$2"
+        nginx.ingress.kubernetes.io/use-regex: "true"
+        nginx.ingress.kubernetes.io/x-forwarded-prefix: "/pool"
+      hosts:
+        - host: "business-partners.tx.test"
+          paths:
+            - path: "/pool(/|$)(.*)"
+              pathType: "ImplementationSpecific"
+    applicationConfig:
+      server:
+        # App should take the x-forward-header-prefix into account for Swagger-UI and redirects to work correctly
+        forward-headers-strategy: "FRAMEWORK"
+      bpdm:
+        security:
+          # App's API is authenticated over Central-IDP
+          auth-server-url: "http://centralidp.tx.test/auth"
+          realm: "CX-Central"
+          # Is Central-IDPs name for the Pool client
+          # The Pool will use that name to check for existing client permissions here
+          client-id: "Cl7-CX-BPDM"
+          # Rename default permission names to be compatible with the configuration from the Central-IDP
+          permissions:
+            readPartner: view_company_data
+            writePartner: add_company_data
+            readMemberPartner: view_company_data
+            readMetaData: view_company_data
+            writeMetaData: add_company_data
+            readChangelog: view_company_data
+            readMemberChangelog: view_company_data
+        # The Pool needs to connect to the Orchestrator to realize the Golden Record Process
+        # Setup client connection (where to connect and the authentication)
+        # By default the Pool assumes that the authentication server of the Orchestrator matches that one of the Pool
+        # We will reuse the general BPDM admin technical user to establish connection between the services
+        client:
+          orchestrator:
+            registration:
+              client-id: *bpdmAdminClientId
+    applicationSecrets:
+      bpdm:
+        client:
+          orchestrator:
+            registration:
+              client-secret: *bpdmAdminClientSecret
+      spring:
+        datasource:
+          # Set the password of the postgres BPDM user here (Currently, BPDM can't deal with random initial passwords)
+          password: *bpdmPostgresPassword
+
+  # Configures the central service for orchestrating the Golden Record Process
+  bpdm-orchestrator:
+    ingress:
+      enabled: true
+      annotations:
+        nginx.ingress.kubernetes.io/rewrite-target: "/$2"
+        nginx.ingress.kubernetes.io/use-regex: "true"
+        nginx.ingress.kubernetes.io/x-forwarded-prefix: "/orchestrator"
+      hosts:
+        - host: "business-partners.tx.test"
+          paths:
+            - path: "/orchestrator(/|$)(.*)"
+              pathType: "ImplementationSpecific"
+    applicationConfig:
+      server:
+        # App should take the x-forward-header-prefix into account for Swagger-UI and redirects to work correctly
+        forward-headers-strategy: "FRAMEWORK"
+      bpdm:
+        security:
+          auth-server-url: "http://centralidp.tx.test/auth"
+          realm: "CX-Central"
+          # The Central-IDP does not yet have dedicated Orchestrator permissions
+          # Therefore, we just reuse the permissions from the Pool for now
+          # Basically it is saying: If you would be able to write into the Pool directly,
+          # you are also able to create golden record tasks which eventually will write data into the Pool
+          # (We are stricter with the permissions now than we will have to be when using dedicated permissions)
+          client-id: "Cl7-CX-BPDM"
+          permissions:
+            createTask: "add_company_data"
+            readTask: "add_company_data"
+            reservation:
+              clean: "add_company_data"
+              cleanAndSync: "add_company_data"
+              poolSync: "add_company_data"
+            result:
+              clean: "add_company_data"
+              cleanAndSync: "add_company_data"
+              poolSync: "add_company_data"
+
+  # This installs a dummy cleaning service which performs rudimentary cleaning operations in order to realize the golden record process
+  bpdm-cleaning-service-dummy:
+    applicationConfig:
+      bpdm:
+        # The cleaning dummy needs to connect to the Orchestrator to realize the Golden Record Process
+        # Setup client connection (where to connect and the authentication)
+        # We reuse the general BPDM admin technical user to establish connection between the services
+        client:
+          orchestrator:
+            provider:
+              issuer-uri: "http://centralidp.tx.test/auth/realms/CX-Central"
+            registration:
+              client-id: *bpdmAdminClientId
+    applicationSecrets:
+      bpdm:
+        client:
+          orchestrator:
+            registration:
+              client-secret: *bpdmAdminClientSecret

--- a/charts/values-test-bpdm.yaml
+++ b/charts/values-test-bpdm.yaml
@@ -1,0 +1,52 @@
+# #############################################################################
+# Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# #############################################################################
+---
+
+portal:
+  enabled: false
+
+centralidp:
+  enabled: true
+
+sharedidp:
+  enabled: false
+
+bpndiscovery:
+  enabled: false
+
+discoveryfinder:
+  enabled: false
+
+selfdescription:
+  enabled: false
+
+managed-identity-wallet:
+  enabled: false
+
+dataconsumer:
+  enabled: false
+
+tx-data-provider:
+  enabled: false
+
+pgadmin4:
+  enabled: false
+
+bpdm:
+  enabled: true


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This pull request adds the BPDM chart for Catena-X 24.05 to the umbrella chart.

The umbrella chart sets up the central Pool component and the necessary components for the golden record process. Also, it creates and configures a Gate for the Portal with which to share business partner data to the golden record process.


> Please note that a hotfix was needed in order to use the BPDM chart as a dependency:  [5.0.3](https://github.com/eclipse-tractusx/bpdm/releases/tag/bpdm-5.0.3). 

> To be honest the need for this hotfix still confuses me. The faulty configuration for 5.0.2 really only takes effect if you use this chart as a dependency but not stand-alone. Maybe someone with better insight into helm can exaplain this. In any case, the Chart is working now as a dependency.


The BPDM component will successfully install with the following command from the root directory:

```bash
helm install  \
 --set centralidp.enabled=true,bpdm.enabled=true \
 --namespace umbrella \
 --generate-name \
 --create-namespace \
 charts/umbrella
```

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
- [x] Create documentation for enabling this component
- [x] Create chart tests for BPDM
