### PR TITLE
Chore: upgrade portal and iam

### DIFF
--- a/charts/umbrella/Chart.yaml
+++ b/charts/umbrella/Chart.yaml
@@ -28,7 +28,7 @@ sources:
   - https://github.com/eclipse-tractusx/tractus-x-umbrella
 
 type: application
-version: 0.16.0
+version: 0.17.0
 
 # when adding or updating versions of dependencies, also update list under README.md#Install
 dependencies:
@@ -36,16 +36,16 @@ dependencies:
   - condition: portal.enabled
     name: portal
     repository: https://eclipse-tractusx.github.io/charts/dev
-    version: 1.8.1
+    version: 2.0.0
   # cx-iam
   - condition: centralidp.enabled
     name: centralidp
     repository: https://eclipse-tractusx.github.io/charts/dev
-    version: 2.1.0
+    version: 3.0.0
   - condition: sharedidp.enabled
     name: sharedidp
     repository: https://eclipse-tractusx.github.io/charts/dev
-    version: 2.1.0
+    version: 3.0.0
   # discovery-finder
   - condition: discoveryfinder.enabled
     name: discoveryfinder

--- a/charts/umbrella/README.md
+++ b/charts/umbrella/README.md
@@ -156,9 +156,9 @@ Select a subset of components which are designed to integrate with each other fo
 
 The currently available components are following:
 
-- [portal](https://github.com/eclipse-tractusx/portal/tree/portal-1.8.1)
-- [centralidp](https://github.com/eclipse-tractusx/portal-iam/tree/v2.1.0)
-- [sharedidp](https://github.com/eclipse-tractusx/portal-iam/tree/v2.1.0)
+- [portal](https://github.com/eclipse-tractusx/portal/tree/portal-2.0.0)
+- [centralidp](https://github.com/eclipse-tractusx/portal-iam/tree/v3.0.0)
+- [sharedidp](https://github.com/eclipse-tractusx/portal-iam/tree/v3.0.0)
 - [bpndiscovery](https://github.com/eclipse-tractusx/sldt-bpn-discovery/tree/bpndiscovery-0.2.2)
 - [discoveryfinder](https://github.com/eclipse-tractusx/sldt-discovery-finder/tree/discoveryfinder-0.2.2)
 - [sdfactory](https://github.com/eclipse-tractusx/sd-factory/tree/sdfactory-2.1.12)

--- a/charts/umbrella/values.yaml
+++ b/charts/umbrella/values.yaml
@@ -33,11 +33,15 @@ portal:
         enabled: false
   portalAddress: "http://portal.tx.test"
   portalBackendAddress: "http://portal-backend.tx.test"
-  centralidpAddress: "http://centralidp.tx.test"
+  centralidp:
+    address: "http://centralidp.tx.test"
   sharedidpAddress: "http://sharedidp.tx.test"
   semanticsAddress: "http://semantics.tx.test"
-  bpdmPartnersPoolAddress: "http://business-partners.tx.test"
-  bpdmPortalGateAddress: "http://business-partners.tx.test"
+  bpdm:
+    poolAddress: "http://business-partners.tx.test"
+    poolApiPath: "/pool/v6"
+    portalGateAddress: "http://business-partners.tx.test"
+    portalGateApiPath: "/gate/v6"
   custodianAddress: "http://managed-identity-wallets.tx.test"
   sdfactoryAddress: "http://sdfactory.tx.test"
   clearinghouseAddress: "http://validation.tx.test"
@@ -101,6 +105,11 @@ portal:
         sdfactoryLibrary: "Debug"
         bpdmLibrary: "Debug"
         custodianLibrary: "Debug"
+      serviceAccount:
+        encryptionConfigs:
+          index0:
+            encryptionKey: "deb8261ec7b89c344f1c5ef5a11606e305f14e0d231b1357d90ad0180c5081d3"
+      issuerdid: "did:web:managed-identity-wallets.tx.test:BPNL00000003CRHK"
       swaggerEnabled: true
     appmarketplace:
       logging:
@@ -126,8 +135,8 @@ portal:
         sdfactoryLibrary: "Debug"
         offerProvider: "Debug"
       bpdm:
-        clientId: "sa-cl7-cx-5"
-        clientSecret: "bWSck103qNJ0jZ1LVtG9mUAlcL7R5RLg"
+        clientId: &bpdmAdminClientId "sa-cl7-cx-5"
+        clientSecret: &bpdmAdminClientSecret "bWSck103qNJ0jZ1LVtG9mUAlcL7R5RLg"
       # -- no configuration for clearinghouse because it's an external component
       # clientId and clientSecret aren't in the centralidp Keycloak
       # clearinghouse:
@@ -143,6 +152,44 @@ portal:
       offerprovider:
         clientId: "sa-cl2-03"
         clientSecret: "wyNYzSnyu4iGvj17XgLSl0aQxAPjTjmI"
+      dim:
+        clientId: "dim-client-id"
+        clientSecret: ""
+        universalResolverAddress: "https://dev.uniresolver.io/"
+        encryptionConfigs:
+          index0:
+            encryptionKey:
+              "6cbaf47ee30c778088e6faa44e2f0eed98beda86db06c7d2e37e32ab78e14b33"
+      issuerComponent:
+        clientId: "sa-cl2-04"
+        clientSecret: "c0gFPfWWUpeOr7MP6DIqdRPhUfaX4GRC"
+        encryptionConfigs:
+          index0:
+            encryptionKey:
+              "39ffab76f99ece1e4ac72f973d5c703737324a75c6445e84fa317a7833476a15"
+      bpnDidResolver:
+        # -- ApiKey for management endpoint of the bpnDidResolver. Secret-key 'bpndidresolver-api-key'.
+        apiKey: ""
+      onboardingServiceProvider:
+        encryptionConfigs:
+          index0:
+            cipherMode: "CBC"
+            paddingMode: "PKCS7"
+            encryptionKey:
+              "f7bc3d99f1ace73e7a75b794affbbc26206ab29909821a102aaccb2e95e45f7c"
+          index1:
+            encryptionKey:
+              "8027152fe7a869c88acc86981760acd70ff1d660c2bd129eece94edef933caf7"
+      invitation:
+        encryptionConfigs:
+          index0:
+            encryptionKey:
+              "d84fea29d6eac0fa51e36682b164e7d61693cd4202ed04306d2d9c5d46655e2c"
+      mailing:
+        encryptionConfigs:
+          index0:
+            encryptionKey:
+              "d2e27d71b018cb36029184852f1baa3e26891be94718f77de4c7cc6c882fe317"
     mailing:
       host: "smtp.tx.test"
       port: "587"
@@ -239,12 +286,12 @@ centralidp:
           - -c
           - |
             echo "Copying realms..."
-            cp -R /import/catenax-central/R2403/realms/* /realms
+            cp -R /import/catenax-central/R2405/realms/* /realms
         volumeMounts:
         - name: realms
           mountPath: "/realms"
       - name: theme-import
-        image: docker.io/tractusx/portal-iam:v2.1.0
+        image: docker.io/tractusx/portal-iam:v3.0.0
         imagePullPolicy: IfNotPresent
         command:
           - sh
@@ -258,7 +305,7 @@ centralidp:
           mountPath: "/themes"
       # uncomment the following line for tls
       # - name: init-certs
-      #   image: docker.io/bitnami/keycloak:22.0.3-debian-11-r14
+      #   image: docker.io/bitnami/keycloak:23.0.7-debian-12-r1
       #   imagePullPolicy: IfNotPresent
       #   command: ["/bin/bash"]
       #   args:
@@ -361,7 +408,7 @@ sharedidp:
         - name: realms
           mountPath: "/realms"
       - name: theme-import
-        image: docker.io/tractusx/portal-iam:v2.1.0
+        image: docker.io/tractusx/portal-iam:v3.0.0
         imagePullPolicy: IfNotPresent
         command:
           - sh
@@ -379,7 +426,7 @@ sharedidp:
           mountPath: "/themes-catenax-shared-portal"
       # uncomment the following line for tls
       # - name: init-certs
-      #   image: docker.io/bitnami/keycloak:22.0.3-debian-11-r14
+      #   image: docker.io/bitnami/keycloak:23.0.7-debian-12-r1
       #   imagePullPolicy: IfNotPresent
       #   command: ["/bin/bash"]
       #   args:


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->
Upgrade Portal to v2.0.0 and, Centralidp to Sharedidp to v3.0.0

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->
In this comment it is requested to do the upgrade in one pull request https://github.com/eclipse-tractusx/tractus-x-umbrella/pull/106#discussion_r1670723925
It will allow compatibility with the BPDM component https://github.com/eclipse-tractusx/tractus-x-umbrella/pull/106#issuecomment-2237960243 

## Pre-review checks

- [ x ] Tested Login, forgot password and company invitation

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ x ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ x ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
