### PR TITLE
docs(readme): fix helm command to populate the miw for E2E Adopter Jo…

### DIFF
--- a/charts/umbrella/README.md
+++ b/charts/umbrella/README.md
@@ -217,7 +217,7 @@ Choose to install one of the predefined subsets (currently in focus of the **E2E
 
 ```bash
 helm install \
-  --set centralidp.enabled=true,managed-identity-wallet.enabled=true,dataconsumerOne.enabled=true,tx-data-provider.enabled=true \
+  --set centralidp.enabled=true,managed-identity-wallet.enabled=true,managed-identity-wallet.seeding.enabled=true,dataconsumerOne.enabled=true,tx-data-provider.enabled=true \
   umbrella tractusx-dev/umbrella \
   --namespace umbrella \
   --create-namespace


### PR DESCRIPTION

## Description
The missing flag prevented the post-install job from executing, which is required to populate the miw with the BPN entries. This issue was preventing the dataconsumerOne from fetching the catalog from the dataprovider since it's entry was missing on the miw.

<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->


<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
