### PR TITLE
docs(portal): enhance documentation for onboarding process

### DIFF
--- a/charts/umbrella/README.md
+++ b/charts/umbrella/README.md
@@ -1,10 +1,18 @@
 - [Umbrella Chart](#umbrella-chart)
   - [Usage](#usage)
     - [Cluster setup](#cluster-setup)
+      - [Linux \& Mac](#linux--mac)
+      - [Windows](#windows)
     - [Network setup](#network-setup)
+      - [Linux \& Mac](#linux--mac-1)
+      - [Windows](#windows-1)
     - [Install](#install)
-      - [Released chart](#use-released-chart)
-      - [Repository](#use-local-repository)
+      - [Use released chart](#use-released-chart)
+        - [Option 1](#option-1)
+        - [Option 2](#option-2)
+      - [Use local repository](#use-local-repository)
+        - [Option 1](#option-1-1)
+        - [Option 2](#option-2-1)
     - [E2E Adopter Journeys](#e2e-adopter-journeys)
       - [Data exchange](#data-exchange)
       - [Get to know the Portal](#get-to-know-the-portal)
@@ -330,7 +338,28 @@ TBD.
 
 #### Get to know the Portal
 
-Perform first login and send out an invitation to a company to join the network (SMTP account required to be configured in custom values.yaml file).
+Perform first login and send out an invitation to a company to join the network (SMTP account required to be configured in custom values.yaml file). Since the onboarding process requires the clearinghouse to work properly, but clearinghouse currently isn't available as a FOSS application you can skip the step with the following SQL Script which must be executed against the portal database.
+
+```sql
+WITH applications AS (
+    SELECT distinct ca.id as Id, ca.checklist_process_id as ChecklistId
+    FROM portal.company_applications as ca
+             JOIN portal.application_checklist as ac ON ca.id = ac.application_id
+    WHERE 
+      ca.application_status_id = 7 
+    AND ac.application_checklist_entry_type_id = 6
+    AND (ac.application_checklist_entry_status_id = 4 OR ac.application_checklist_entry_status_id = 1)
+),
+updated AS (
+ UPDATE portal.application_checklist
+     SET application_checklist_entry_status_id = 3
+     WHERE application_id IN (SELECT Id FROM applications)
+     RETURNING *
+)
+INSERT INTO process_steps (id, process_step_type_id, process_step_status_id, date_created, date_last_changed, process_id, message)
+SELECT gen_random_uuid(), 12, 1, now(), NULL, a.ChecklistId, NULL
+FROM applications a;
+```
 
 Proceed with the login to the <http://portal.tx.test> to verify that everything is setup as expected.
 

--- a/charts/umbrella/README.md
+++ b/charts/umbrella/README.md
@@ -16,6 +16,7 @@
     - [E2E Adopter Journeys](#e2e-adopter-journeys)
       - [Data exchange](#data-exchange)
       - [Get to know the Portal](#get-to-know-the-portal)
+      - [Note for onboarding process](#note-for-onboarding-process)
     - [Uninstall](#uninstall)
     - [Ingresses](#ingresses)
     - [Database Access](#database-access)
@@ -338,28 +339,7 @@ TBD.
 
 #### Get to know the Portal
 
-Perform first login and send out an invitation to a company to join the network (SMTP account required to be configured in custom values.yaml file). Since the onboarding process requires the clearinghouse to work properly, but clearinghouse currently isn't available as a FOSS application you can skip the step with the following SQL Script which must be executed against the portal database.
-
-```sql
-WITH applications AS (
-    SELECT distinct ca.id as Id, ca.checklist_process_id as ChecklistId
-    FROM portal.company_applications as ca
-             JOIN portal.application_checklist as ac ON ca.id = ac.application_id
-    WHERE 
-      ca.application_status_id = 7 
-    AND ac.application_checklist_entry_type_id = 6
-    AND (ac.application_checklist_entry_status_id = 4 OR ac.application_checklist_entry_status_id = 1)
-),
-updated AS (
- UPDATE portal.application_checklist
-     SET application_checklist_entry_status_id = 3
-     WHERE application_id IN (SELECT Id FROM applications)
-     RETURNING *
-)
-INSERT INTO portal.process_steps (id, process_step_type_id, process_step_status_id, date_created, date_last_changed, process_id, message)
-SELECT gen_random_uuid(), 12, 1, now(), NULL, a.ChecklistId, NULL
-FROM applications a;
-```
+Perform first login and send out an invitation to a company to join the network (SMTP account required to be configured in custom values.yaml file).
 
 Proceed with the login to the <http://portal.tx.test> to verify that everything is setup as expected.
 
@@ -411,6 +391,31 @@ In case that you have TLS enabled (see [Self-signed TLS setup (Optional)](#self-
 - <https://sharedidp.tx.test/auth/>
 - <https://portal-backend.tx.test>
 - <https://portal.tx.test>
+
+#### Note for onboarding process
+
+ Since the onboarding process requires the [Clearinghouse](https://github.com/eclipse-tractusx/portal-assets/blob/v2.1.0/docs/developer/Technical%20Documentation/Interface%20Contracts/Clearinghouse.md) to work properly, but ClearingHouse currently isn't available as a FOSS application you can skip the step with the following SQL Script which must be executed against the portal database.
+
+```sql
+WITH applications AS (
+    SELECT distinct ca.id as Id, ca.checklist_process_id as ChecklistId
+    FROM portal.company_applications as ca
+             JOIN portal.application_checklist as ac ON ca.id = ac.application_id
+    WHERE 
+      ca.application_status_id = 7 
+    AND ac.application_checklist_entry_type_id = 6
+    AND (ac.application_checklist_entry_status_id = 4 OR ac.application_checklist_entry_status_id = 1)
+),
+updated AS (
+ UPDATE portal.application_checklist
+     SET application_checklist_entry_status_id = 3
+     WHERE application_id IN (SELECT Id FROM applications)
+     RETURNING *
+)
+INSERT INTO portal.process_steps (id, process_step_type_id, process_step_status_id, date_created, date_last_changed, process_id, message)
+SELECT gen_random_uuid(), 12, 1, now(), NULL, a.ChecklistId, NULL
+FROM applications a;
+```
 
 ### Uninstall
 

--- a/charts/umbrella/README.md
+++ b/charts/umbrella/README.md
@@ -356,7 +356,7 @@ updated AS (
      WHERE application_id IN (SELECT Id FROM applications)
      RETURNING *
 )
-INSERT INTO process_steps (id, process_step_type_id, process_step_status_id, date_created, date_last_changed, process_id, message)
+INSERT INTO portal.process_steps (id, process_step_type_id, process_step_status_id, date_created, date_last_changed, process_id, message)
 SELECT gen_random_uuid(), 12, 1, now(), NULL, a.ChecklistId, NULL
 FROM applications a;
 ```

--- a/charts/umbrella/README.md
+++ b/charts/umbrella/README.md
@@ -16,7 +16,7 @@
     - [E2E Adopter Journeys](#e2e-adopter-journeys)
       - [Data exchange](#data-exchange)
       - [Get to know the Portal](#get-to-know-the-portal)
-      - [Note for onboarding process](#note-for-onboarding-process)
+        - [Note for onboarding process](#note-for-onboarding-process)
     - [Uninstall](#uninstall)
     - [Ingresses](#ingresses)
     - [Database Access](#database-access)
@@ -392,7 +392,7 @@ In case that you have TLS enabled (see [Self-signed TLS setup (Optional)](#self-
 - <https://portal-backend.tx.test>
 - <https://portal.tx.test>
 
-#### Note for onboarding process
+##### Note for onboarding process
 
  Since the onboarding process requires the [Clearinghouse](https://github.com/eclipse-tractusx/portal-assets/blob/v2.1.0/docs/developer/Technical%20Documentation/Interface%20Contracts/Clearinghouse.md) to work properly, but ClearingHouse currently isn't available as a FOSS application you can skip the step with the following SQL Script which must be executed against the portal database.
 


### PR DESCRIPTION
## Description

* enhance portal description to provide a script to skip the clearinghouse step for a successful onboarding

## Why

Without the script the clearinghouse step will fail, since there isn't a clearinghouse FOSS application

## Issue

Refs: #115

## Pre-review checks

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
