### PR TITLE
Fix hostname of portal backend database

### DIFF
--- a/charts/umbrella/README.md
+++ b/charts/umbrella/README.md
@@ -626,7 +626,7 @@ In the following some of the available connections:
 Host:
 
 ```
-portal-backend-postgresql
+umbrella-portal-backend-postgresql
 ```
 
 Password:


### PR DESCRIPTION
The name of the portal-backend-postgresql in the README is wrong, it needs to be prefixed with `umbrella-` (as are all the others)

