### PR TITLE
feat: Update SSI-Credential-Issuer version

### DIFF
--- a/charts/umbrella/Chart.yaml
+++ b/charts/umbrella/Chart.yaml
@@ -28,7 +28,7 @@ sources:
   - https://github.com/eclipse-tractusx/tractus-x-umbrella
 
 type: application
-version: 2.0.3
+version: 2.0.4
 
 # when adding or updating versions of dependencies, also update list under README.md#Install
 dependencies:
@@ -66,7 +66,7 @@ dependencies:
   - name: ssi-credential-issuer
     condition: ssi-credential-issuer.enabled
     repository: https://eclipse-tractusx.github.io/charts/dev
-    version: 1.0.0
+    version: 1.1.0
   # semantic-hub
   - condition: semantic-hub.enabled
     name: semantic-hub

--- a/charts/umbrella/values.yaml
+++ b/charts/umbrella/values.yaml
@@ -739,11 +739,6 @@ ssi-credential-issuer:
       clientId: "wallet-client-id"
       # -- Client-secret for wallet client-id. Secret-key 'wallet-client-secret'.
       clientSecret: ""
-      encryptionConfigIndex: 0
-      encryptionConfigs:
-        index0:
-          # EncryptionKey for wallet. Secret-key 'process-wallet-encryption-key0'. Expected format is 256 bit (64 digits) hex.
-          encryptionKey: "deb8261ec7b89c344f1c5ef5a11606e305f14e0d231b1357d90ad0180c5081d3"
   migrations:
     logging:
       default: "Debug"

--- a/charts/umbrella/values.yaml
+++ b/charts/umbrella/values.yaml
@@ -702,7 +702,7 @@ ssi-credential-issuer:
   portalBackendAddress: "http://portal-backend.tx.test"
   walletAddress: "http://ssi-dim-wallet-stub.tx.test"
   walletTokenAddress: "http://ssi-dim-wallet-stub.tx.test/oauth/token"
-  issuer:
+  service:
     swaggerEnabled: true
     logging:
       businessLogic: "Debug"
@@ -744,7 +744,7 @@ ssi-credential-issuer:
         index0:
           # EncryptionKey for wallet. Secret-key 'process-wallet-encryption-key0'. Expected format is 256 bit (64 digits) hex.
           encryptionKey: "deb8261ec7b89c344f1c5ef5a11606e305f14e0d231b1357d90ad0180c5081d3"
-  issuermigrations:
+  migrations:
     logging:
       default: "Debug"
   credentialExpiry:


### PR DESCRIPTION
## Description

Update the SSI-Credential-Issuer version to 1.1.0 [#135](https://github.com/eclipse-tractusx/tractus-x-umbrella/issues/135)

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
