### PR TITLE
chore: updated edc urls

### DIFF
--- a/charts/umbrella/Chart.yaml
+++ b/charts/umbrella/Chart.yaml
@@ -28,7 +28,7 @@ sources:
   - https://github.com/eclipse-tractusx/tractus-x-umbrella
 
 type: application
-version: 2.0.8
+version: 2.0.10
 
 # when adding or updating versions of dependencies, also update list under README.md#Install
 dependencies:

--- a/charts/umbrella/values.yaml
+++ b/charts/umbrella/values.yaml
@@ -1118,7 +1118,7 @@ dataconsumerOne:
         EDC_IAM_DID_WEB_USE_HTTPS: false
       ingresses:
         - enabled: true
-          hostname: "dataconsumer-1"
+          hostname: "dataconsumer-1-dataplane.tx.test"
           endpoints:
             - default
             - public

--- a/charts/umbrella/values.yaml
+++ b/charts/umbrella/values.yaml
@@ -216,82 +216,82 @@ portal:
             # BPN is retrieved from participant id of the dataconsumerOne
             dataconsumerOne:
               name: "BPN_OEM_C"
-              connectorUrl: "http://dataconsumer-1-dataplane.tx.test/api/v1/dsp"
+              connectorUrl: "http://dataconsumer-1-controlplane.tx.test/api/v1/dsp"
               connectorName: "BPN OEM C Connector"
             # BPN is retrieved from participant id of the tx-data-provider
             tx-data-provider:
               name: "BPN_OEM_A"
-              connectorUrl: "http://dataprovider-dataplane.tx.test/api/v1/dsp"
+              connectorUrl: "http://dataprovider-controlplane.tx.test/api/v1/dsp"
               connectorName: "BPN OEM A Connector"
             # BPN is retrieved from participant id of the dataconsumerTwo
             dataconsumerTwo:
               name: "BPN_OEM_B"
-              connectorUrl: "http://dataconsumer-2-dataplane.tx.test/api/v1/dsp"
+              connectorUrl: "http://dataconsumer-2-controlplane.tx.test/api/v1/dsp"
               connectorName: "BPN OEM B Connector"
             company4:
               name: "BPN_IRS_TEST"
               bpn: "BPNL00000003AWSS"
-              connectorUrl: "http://company4-dataplane.tx.test/api/v1/dsp"
+              connectorUrl: "http://company4-controlplane.tx.test/api/v1/dsp"
               connectorName: "BPN IRS TEST Connector"
             company5:
               name: "BPN_N_TIER_A"
               bpn: "BPNL00000003B0Q0"
-              connectorUrl: "http://company5-dataplane.tx.test/api/v1/dsp"
+              connectorUrl: "http://company5-controlplane.tx.test/api/v1/dsp"
               connectorName: "BPN N TIER A Connector"
             company6:
               name: "BPN_TRACEX_A_SITE_A"
               bpn: "BPNS0000000008ZZ"
-              connectorUrl: "http://company6-dataplane.tx.test/api/v1/dsp"
+              connectorUrl: "http://company6-controlplane.tx.test/api/v1/dsp"
               connectorName: "BPN TRACEX A SITE A Connector"
             company7:
               name: "BPN_TRACEX_B"
               bpn: "BPNL00000003CNKC"
-              connectorUrl: "http://company7-dataplane.tx.test/api/v1/dsp"
+              connectorUrl: "http://company7-controlplane.tx.test/api/v1/dsp"
               connectorName: "BPN TRACEX B Connector"
             company8:
               name: "BPN_DISMANTLER"
               bpn: "BPNL00000003B6LU"
-              connectorUrl: "http://company8-dataplane.tx.test/api/v1/dsp"
+              connectorUrl: "http://company8-controlplane.tx.test/api/v1/dsp"
               connectorName: "BPN DISMANTLER Connector"
             company9:
               name: "BPN_TRACEX_A"
               bpn: "BPNL00000003CML1"
-              connectorUrl: "http://company9-dataplane.tx.test/api/v1/dsp"
+              connectorUrl: "http://company9-controlplane.tx.test/api/v1/dsp"
               connectorName: "BPN TRACEX A Connector"
             company10:
               name: "BPN_TRACEX_B_SITE_A"
               bpn: "BPNS00000008BDFH"
-              connectorUrl: "http://company10-dataplane.tx.test/api/v1/dsp"
+              connectorUrl: "http://company10-controlplane.tx.test/api/v1/dsp"
               connectorName: "BPN TRACEX B SITE A Connector"
             company11:
               name: "BPN_TIER_A"
               bpn: "BPNL00000003B2OM"
-              connectorUrl: "http://company11-dataplane.tx.test/api/v1/dsp"
+              connectorUrl: "http://company11-controlplane.tx.test/api/v1/dsp"
               connectorName: "BPN TIER A Connector"
             company12:
               name: "BPN_TIER_C"
               bpn: "BPNL00000003CSGV"
-              connectorUrl: "http://company12-dataplane.tx.test/api/v1/dsp"
+              connectorUrl: "http://company12-controlplane.tx.test/api/v1/dsp"
               connectorName: "BPN TIER C Connector"
             company13:
               name: "BPN_TIER_B"
               bpn: "BPNL00000003B5MJ"
-              connectorUrl: "http://company13-dataplane.tx.test/api/v1/dsp"
+              connectorUrl: "http://company13-controlplane.tx.test/api/v1/dsp"
               connectorName: "BPN TIER B Connector"
             company14:
               name: "BPN_SUB_TIER_B"
               bpn: "BPNL00000003AXS3"
-              connectorUrl: "http://company14-dataplane.tx.test/api/v1/dsp"
+              connectorUrl: "http://company14-controlplane.tx.test/api/v1/dsp"
               connectorName: "BPN SUB TIER B Connector"
             company15:
               name: "BPN_SUB_TIER_A"
               bpn: "BPNL00000003B3NX"
-              connectorUrl: "http://company15-dataplane.tx.test/api/v1/dsp"
+              connectorUrl: "http://company15-controlplane.tx.test/api/v1/dsp"
               connectorName: "BPN SUB TIER A Connector"
             company16:
               name: "BPN_SUB_TIER_C"
               bpn: "BPNL00000000BJTL"
-              connectorUrl: "http://company16-dataplane.tx.test/api/v1/dsp"
+              connectorUrl: "http://company16-controlplane.tx.test/api/v1/dsp"
               connectorName: "BPN SUB TIER C Connector"
       logging:
         default: "Debug"
@@ -1118,7 +1118,7 @@ dataconsumerOne:
         EDC_IAM_DID_WEB_USE_HTTPS: false
       ingresses:
         - enabled: true
-          hostname: "dataconsumer-1-dataplane.tx.test"
+          hostname: "dataconsumer-1"
           endpoints:
             - default
             - public


### PR DESCRIPTION
## Description

The urls are belonging to the control plane. So we should state "controlplane" in the seeding urls.


## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
