### PR TITLE
docs(data exchange): adapt and restructure the data exchange

### DIFF
--- a/docs/user/guides/data-exchange/consume-data.md
+++ b/docs/user/guides/data-exchange/consume-data.md
@@ -34,7 +34,7 @@ curl -L -X POST 'http://dataconsumer-1-controlplane.tx.test/management/v2/catalo
 
 ### Catalog response
 
-We learned already about the response of a catalog request in the [Provide Data](provide-data.md) guide. The response contains a list of assets that Alice can consume from Bob.
+We have already learned about the response of a catalog request in the [Provide Data](provide-data.md) guide. The response contains a list of assets that Alice can consume from Bob.
 
 The response (here just an extract) will contain the `@id` `200` of the asset that Alice wants to consume, but also the `@id` `MjAw:MjAw:Y2ZjMzdlNmUtODAwNi00NGJjLWJhMWYtNjJkOWIzZWM0ZTQ3` of the offer
 that Alice needs to reference in the negotiation.
@@ -220,7 +220,7 @@ The response will contain the authorization details, including the `endpoint` an
 ## Step 5: Fetch data
 
 Using the {{ENDPOINT}} and {{TOKEN}} from the response, Alice fetches the data. In our example the `uuid` `urn:uuid:b77c6d51-cd1f-4c9d-b5d4-091b22dd306b` for the data is already known. In
-real life you would receive this information from the digital twin registry asn an endpoint in the submodelDescriptors.
+real life you would receive this information from the digital twin registry as an endpoint in the submodelDescriptors.
 
 ### Fetch data request
 

--- a/docs/user/guides/data-exchange/consume-data.md
+++ b/docs/user/guides/data-exchange/consume-data.md
@@ -1,126 +1,272 @@
 # Consume Data
+
 In order to be able to consume data, it is necessary to have previously [provided](./provide-data.md).
-> Variables enclosed in {{ }} mean that they are whose content has been obtained from the answers of previous calls.
 
-## 1. Query Catalog
+> **Please** have a look at the `cURL explanation` Notes in the beginning of [Provide Data](provide-data.md) to get more information about cURL. 
 
-```
+This step continues the journey of our data consumer Alice. After the data provider Bob has successfully provided his data as a contract definition in his catalog. Alice will now consume the data.
+We will use plain CLI tools (`curl`) for this, but feel free to use graphical tools such as Postman or Insomnia.
+
+## Step 1: Request the catalog
+
+To see Bob's data offerings, Alice must request access to his catalog. The catalog shows all the assets that Alice can consume from Bob.
+
+### Catalog request (Alice)
+
+```bash
 curl -L -X POST 'http://dataconsumer-1-controlplane.tx.test/management/v2/catalog/request' \
--H 'Content-Type: application/json' \
--H 'X-Api-Key: TEST1' \
---data-raw '{
-  "@context": {
-    "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
-  },
-  "@type": "CatalogRequest",
-  "counterPartyAddress": "http://dataprovider-controlplane.tx.test/api/v1/dsp",
-  "counterPartyId": "BPNL00000003AYRE",
-  "protocol": "dataspace-protocol-http",
-  "querySpec": {
-    "offset": 0,
-    "limit": 50
-  }
-}'
-```
-
-We get the {{offer_id}} from the response.
-
-## 2. Initiate Negotiation
-```
-curl -L -X POST 'http://dataconsumer-1-controlplane.tx.test/management/v2/contractnegotiations' \
--H 'Content-Type: application/json' \
--H 'X-Api-Key: TEST1' \
---data-raw '{
-	"@context": {
-		"@vocab": "https://w3id.org/edc/v0.0.1/ns/"
-	},
-	"@type": "NegotiationInitiateRequestDto",
-	"counterPartyAddress": "http://dataprovider-controlplane.tx.test/api/v1/dsp",
-	"protocol": "dataspace-protocol-http",
-	"policy": {
-		"@context": "http://www.w3.org/ns/odrl.jsonld",
-		"@type": "odrl:Offer",
-		"@id": "",
-         "assigner": "BPNL00000003AYRE",
-		"permission": {
-			"odrl:target": "200",
-			"odrl:action": {
-				"odrl:type": "USE"
-			},
-			"odrl:constraint": {
-				"odrl:or": {
-					"odrl:leftOperand": "BusinessPartnerNumber",
-					"odrl:operator": {
-						"@id": "odrl:eq"
-					},
-					"odrl:rightOperand": "BPNL00000003AZQP"
-				}
-			}
-		},
-		"prohibition": [],
-		"obligation": [],
-		"target": "200"
-	}
-}'
-```
-
-We get {{negotiation_id}} from the response.
-
-## 3. Get Negotiation By ID
-
-```
-curl -L -X GET 'http://dataconsumer-1-controlplane.tx.test/management/v2/contractnegotiations/' \
--H 'X-Api-Key: TEST1'
-```
-You should be able to see in the response, that the _state_ value is equal to _FINALIZED_.
-
-We get {{contractagreement_id}} from the response.
-
-## 4. Initiate Transfer
-
-```
-curl -L -X POST 'http://dataconsumer-1-controlplane.tx.test/management/v2/transferprocesses' \
--H 'Content-Type: application/json' \
--H 'X-Api-Key: TEST1' \
---data-raw '{
-  "@context": {
-    "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
-  },
-  "@type": "TransferRequest",
-  "protocol": "dataspace-protocol-http",
-  "counterPartyAddress": "http://dataprovider-controlplane.tx.test/api/v1/dsp",
-  "contractId": "",
-  "assetId": "200",
-  "transferType": "HttpData-PULL",
-  "dataDestination":  {
-    "type": "HttpProxy"
-  },
-  "connectorId": "BPNL00000003AZQP",
-  "callbackAddresses": [
-    {
-      "transactional": true,
-      "uri": "http://dataprovider-submodelserver.tx.test/api/v1/transfers"
+  -H 'Content-Type: application/json' \
+  -H 'X-Api-Key: TEST1' \
+  --data-raw '{
+    "@context": {
+      "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+    },
+    "@type": "CatalogRequest",
+    "counterPartyAddress": "http://dataprovider-controlplane.tx.test/api/v1/dsp",
+    "counterPartyId": "BPNL00000003AYRE",
+    "protocol": "dataspace-protocol-http",
+    "querySpec": {
+      "offset": 0,
+      "limit": 50
     }
-  ]
-}'
+  }' | jq
 ```
 
-We get {{transfer_id}} from the response
+### Catalog response
 
-## 5. Get Transfer by ID
+We learned already about the response of a catalog request in the [Provide Data](provide-data.md) guide. The response contains a list of assets that Alice can consume from Bob.
 
+The response (here just an extract) will contain the `@id` `200` of the asset that Alice wants to consume, but also the `@id` `MjAw:MjAw:Y2ZjMzdlNmUtODAwNi00NGJjLWJhMWYtNjJkOWIzZWM0ZTQ3` of the offer
+that Alice needs to reference in the negotiation.
+
+```json
+{
+  "@id": "200",
+  "@type": "dcat:Dataset",
+  "odrl:hasPolicy": {
+    "@id": "MjAw:MjAw:Y2ZjMzdlNmUtODAwNi00NGJjLWJhMWYtNjJkOWIzZWM0ZTQ3",
+    "@type": "odrl:Offer",
+    "odrl:permission": {
+      "odrl:action": {
+        "odrl:type": "USE"
+      },
+      "odrl:constraint": {
+        "odrl:or": {
+          "odrl:leftOperand": "BusinessPartnerNumber",
+          "odrl:operator": {
+            "@id": "odrl:eq"
+          },
+          "odrl:rightOperand": "BPNL00000003AZQP"
+        }
+      }
+    }
+  }
+}
 ```
-curl -L -X GET 'http://dataconsumer-1-controlplane.tx.test/management/v2/transferprocesses/{{transfer_id}}' \
--H 'X-Api-Key: TEST1'
+
+## Step 2: Initiate an edr
+
+To consume the data, Alice uses the `OFFER_ID` `MjAw:MjAw:Y2ZjMzdlNmUtODAwNi00NGJjLWJhMWYtNjJkOWIzZWM0ZTQ3` from the previous catalog response and the target `ASSET_ID` `200` to initiate an [EDR](https://github.com/eclipse-tractusx/tractusx-edc/blob/main/docs/usage/management-api-walkthrough/07_edrs.md).
+
+### EDR request
+
+```bash
+curl -L -X POST 'http://dataconsumer-1-controlplane.tx.test/management/v2/edrs' \
+  -H 'Content-Type: application/json' \
+  -H 'X-Api-Key: TEST1' \
+  --data-raw '{
+    "@context": [
+      "https://w3id.org/tractusx/policy/v1.0.0",
+      "http://www.w3.org/ns/odrl.jsonld",
+      { "@vocab": "https://w3id.org/edc/v0.0.1/ns/" }
+    ],
+    "@type": "ContractRequest",
+    "counterPartyAddress": "http://dataprovider-controlplane.tx.test/api/v1/dsp",
+    "protocol": "dataspace-protocol-http",
+    "policy": {
+      "assigner": "BPNL00000003AYRE",
+      "target": "{{ASSET_ID}}",
+      "@id": "{{OFFER_ID}}",
+        "@type": "odrl:Offer",
+        "odrl:permission": {
+          "odrl:action": {
+            "odrl:type": "USE"
+          },
+          "odrl:constraint": {
+            "odrl:or": {
+              "odrl:leftOperand": "BusinessPartnerNumber",
+              "odrl:operator": {
+                "@id": "odrl:eq"
+              },
+              "odrl:rightOperand": "BPNL00000003AZQP"
+            }
+          }
+        },
+        "odrl:prohibition": [],
+        "odrl:obligation": []
+    },
+    "callbackAddresses": []
+  }' | jq
 ```
 
-You should be able to see in the response that the _state_ value is equal to _STARTED_.
+### EDR response
 
-## 6. Validate Transfer
+The response also includes the `@id` `4b260501-ae2f-46f4-9efc-01ba5a0b3d96` of the EDR, which Alice can use to get the EDR and more information.
 
+```json
+{
+  "@type": "IdResponse",
+  "@id": "4b260501-ae2f-46f4-9efc-01ba5a0b3d96",
+  "createdAt": 1732726185609,
+  "@context": {
+    "@vocab": "https://w3id.org/edc/v0.0.1/ns/",
+    "edc": "https://w3id.org/edc/v0.0.1/ns/",
+    "tx": "https://w3id.org/tractusx/v0.0.1/ns/",
+    "tx-auth": "https://w3id.org/tractusx/auth/",
+    "cx-policy": "https://w3id.org/catenax/policy/",
+    "odrl": "http://www.w3.org/ns/odrl/2/"
+  }
+}
 ```
-curl -L -X GET 'http://dataprovider-submodelserver.tx.test/api/v1/transfers/TEST1/contents'
+
+## Step 3: Query cached edrs
+
+Alice now queries cached EDRs using the {{CONTRACT_NEGOTIATION_ID}} `4b260501-ae2f-46f4-9efc-01ba5a0b3d96` from the previous response.
+
+### Query edrs request
+
+```shell
+curl -L -X POST 'http://dataconsumer-1-controlplane.tx.test/management/v2/edrs/request' \
+  -H 'Content-Type: application/json' \
+  -H 'X-Api-Key: TEST1' \
+  --data-raw '{
+    "@context": { "@vocab": "https://w3id.org/edc/v0.0.1/ns/" },
+    "@type": "QuerySpec",
+    "filterExpression": [
+      {
+        "operandLeft": "contractNegotiationId",
+        "operator": "=",
+        "operandRight": "{{CONTRACT_NEGOTIATION_ID}}"
+      }
+    ]
+  }' | jq
 ```
+
+### Query edrs response
+
+The response will contain the EDR with the `@id` `bdd4af10-9e4a-4796-b4b7-7ecdf91a533a` and the `transferProcessId` `bdd4af10-9e4a-4796-b4b7-7ecdf91a533a`, which is important for the next step. of the contract agreement.
+
+```json
+{
+  "@id": "bdd4af10-9e4a-4796-b4b7-7ecdf91a533a",
+  "@type": "EndpointDataReferenceEntry",
+  "providerId": "BPNL00000003AYRE",
+  "assetId": "200",
+  "agreementId": "2ece6f45-ff09-4417-b5a9-a92a1849f1d0",
+  "transferProcessId": "bdd4af10-9e4a-4796-b4b7-7ecdf91a533a",
+  "createdAt": 1732726189831,
+  "contractNegotiationId": "4b260501-ae2f-46f4-9efc-01ba5a0b3d96",
+  "@context": {
+    "@vocab": "https://w3id.org/edc/v0.0.1/ns/",
+    "edc": "https://w3id.org/edc/v0.0.1/ns/",
+    "tx": "https://w3id.org/tractusx/v0.0.1/ns/",
+    "tx-auth": "https://w3id.org/tractusx/auth/",
+    "cx-policy": "https://w3id.org/catenax/policy/",
+    "odrl": "http://www.w3.org/ns/odrl/2/"
+  }
+}
+```
+
+## Step 4: Get authorization details
+
+Alice uses the {{TRANSFER_PROCESS_ID}} `bdd4af10-9e4a-4796-b4b7-7ecdf91a533a` to get authorization details.
+
+### Authorization request
+
+```bash
+curl -L -X GET 'http://dataconsumer-1-controlplane.tx.test/management/v2/edrs/{{TRANSFER_PROCESS_ID}}/dataaddress?auto_refresh=true' \
+  -H 'Content-Type: application/json' \
+  -H 'X-Api-Key: TEST1' | jq
+```
+
+### Authorization response
+
+
+The response will contain the authorization details, including the `endpoint` and `authorization`which are needed to fetch the data via the data plane.
+
+```json
+{
+  "@type": "DataAddress",
+  "endpointType": "https://w3id.org/idsa/v4.1/HTTP",
+  "tx-auth:refreshEndpoint": "http://dataprovider-dataplane.tx.test/api/public/token",
+  "tx-auth:audience": "did:web:ssi-dim-wallet-stub.tx.test:BPNL00000003AZQP",
+  "type": "https://w3id.org/idsa/v4.1/HTTP",
+  "endpoint": "http://dataprovider-dataplane.tx.test/api/public",
+  "tx-auth:refreshToken": "eyJraWQiOiJ0b2tlblNpZ25lclB1YmxpY0tleSIsImFsZyI6IlJTMjU2In0.eyJleHAiOjE3MzI3MjY0ODksImlhdCI6MTczMjcyNjE4OSwianRpIjoiODA2OTAwYmQtNGY4MS00MzhmLTgyMjYtZDc2ZjkzMmY2MjI1In0.JpTIrOJv609vX86i-y-O8sQcKoTJcWvipC6jyBgWqcEIMWm4dmm4T72z-Z68l1X7QnVq1Ak8JB-fA05ONNL1JjU0W7j6rJK01M2Xo641RpecimxuFhlnld55CPks2wRbbbzHADn8kpqRf2dtNrnsiuRsnzAi6KAkFAEHLB7eLjceNbkk6df3hJrLfnn0DZ6M-OR0O05SgtEyHFsyMpf4OALQwVREIkC7LBTWn7nYCpmzK4ilrL3eM5ZRrbweQ96Tbwi-rfPfp-ptnelO_GGnqzyQef2DN5Eg4P5QZV4QX62Bw0eoYVncgCP6ZKibymnlASG0xHwgEJitu3ZSxBXt-w",
+  "tx-auth:expiresIn": "300",
+  "authorization": "eyJraWQiOiJ0b2tlblNpZ25lclB1YmxpY0tleSIsImFsZyI6IlJTMjU2In0.eyJpc3MiOiJCUE5MMDAwMDAwMDNBWVJFIiwiYXVkIjoiQlBOTDAwMDAwMDAzQVpRUCIsInN1YiI6IkJQTkwwMDAwMDAwM0FZUkUiLCJleHAiOjE3MzI3MjY0ODksImlhdCI6MTczMjcyNjE4OSwianRpIjoiODRkZDIxOGItMzk1ZC00YmExLTg2OWUtOWYzMjI3ZWM0NWFlIn0.jTKEv8Fh75W1JOwrFUo1wyLdUOyBn3g500dWNUbaEC_bgASPImXfXnY3rhIVr_hrFY-anJIB_a6SkpTWb7lycCh2dcMaOmUVgmdKTcEvTr2blAXD_WUZTQYxHDVsMuPXDbX-30tYM4KVPOyemfe7IreB38n104j_SLo2Dr1BrbN9xU7mUm6DeKv1oi0TFRxnmhwnRx4hK1eBYIO-FuA9h1RDvfLWXW5yF55KkkrRTjX2HKqVPAtHInMZBRDhqB298N_VLpwQMtg9nkElzNWIUqEV4zQ1YLSsGNLSxog7JwuL3Tvy1VCOkzDkr6K89Z4IWEF0GzPjXO6Z-li_Vv7DVw",
+  "tx-auth:refreshAudience": "did:web:ssi-dim-wallet-stub.tx.test:BPNL00000003AZQP",
+  "@context": {
+    "@vocab": "https://w3id.org/edc/v0.0.1/ns/",
+    "edc": "https://w3id.org/edc/v0.0.1/ns/",
+    "tx": "https://w3id.org/tractusx/v0.0.1/ns/",
+    "tx-auth": "https://w3id.org/tractusx/auth/",
+    "cx-policy": "https://w3id.org/catenax/policy/",
+    "odrl": "http://www.w3.org/ns/odrl/2/"
+  }
+}
+```
+
+## Step 5: Fetch data
+
+Using the {{ENDPOINT}} and {{TOKEN}} from the response, Alice fetches the data. In our example the `uuid` `urn:uuid:b77c6d51-cd1f-4c9d-b5d4-091b22dd306b` for the data is already known. In
+real life you would receive this information from the digital twin registry asn an endpoint in the submodelDescriptors.
+
+### Fetch data request
+
+```bash
+curl -L -X GET '{{ENDPOINT}}/urn:uuid:b77c6d51-cd1f-4c9d-b5d4-091b22dd306b' \
+  -H 'Authorization: {{TOKEN}}'
+```
+
+### Fetch data response
+
+```json
+{
+  "parentParts": [
+    {
+      "validityPeriod": {
+        "validFrom": "2023-03-21T08:47:14.438+01:00",
+        "validTo": "2024-08-02T09:00:00.000+01:00"
+      },
+      "parentCatenaXId": "urn:uuid:0733946c-59c6-41ae-9570-cb43a6e4c79e",
+      "quantity": {
+        "quantityNumber": 2.5,
+        "measurementUnit": "unit:litre"
+      },
+      "createdOn": "2022-02-03T14:48:54.709Z",
+      "lastModifiedOn": "2022-02-03T14:48:54.709Z"
+    },
+    {
+      "validityPeriod": {
+        "validFrom": "2023-03-21T08:47:14.438+01:00",
+        "validTo": "2024-08-02T09:00:00.000+01:00"
+      },
+      "parentCatenaXId": "urn:uuid:68904173-ad59-4a77-8412-3e73fcafbd8b",
+      "quantity": {
+        "quantityNumber": 2.5,
+        "measurementUnit": "unit:litre"
+      },
+      "createdOn": "2022-02-03T14:48:54.709Z",
+      "lastModifiedOn": "2022-02-03T14:48:54.709Z"
+    }
+  ],
+  "catenaXId": "urn:uuid:2c57b0e9-a653-411d-bdcd-64787e9fd3a7"
+}
+```
+
+> **Congratulations**
+> You have successfully consumed data from Bob.
 
 ## NOTICE
 

--- a/docs/user/guides/data-exchange/provide-data.md
+++ b/docs/user/guides/data-exchange/provide-data.md
@@ -135,7 +135,7 @@ The second request will return all assets. It's called `request catalog` and wil
 
 ## Request the catalog
 
-Once the asset is created, Alice (the data consumer) can try request a catalog of available (offered) data.
+Once the asset is created, Alice (the data consumer) can try to request a catalog of available (offered) data.
 
 > **Note**
 > 
@@ -357,7 +357,7 @@ The policy was successfully created, if the response is something like this
 
 ### Step 2: Request catalog - second try
 
-Now that Bob created an access policy, Alice can once again try to access Bob's offer by running this `curl`.
+Now that Bob has created an access policy, Alice can once again try to access Bob's offer by running this `curl`.
 
 ```shell
 curl -L -X POST 'http://dataconsumer-1-controlplane.tx.test/management/v2/catalog/request' \

--- a/docs/user/guides/data-exchange/provide-data.md
+++ b/docs/user/guides/data-exchange/provide-data.md
@@ -1,112 +1,642 @@
 # Provide Data
 
+This documentation guides you through the process of creating and providing data in a local dataspace using the Eclipse Dataspace Connector (EDC).
+You'll create an asset, define policies, and set up a contract definition for data sharing.
+
+> **cURL explanation**
+>
+> 1. **URL and Method**:
+>    - `-L`: Ensures redirections are followed if the URL returns a redirect response.
+>    - `-X POST`: Specifies the HTTP method as `POST`.
+>
+> 2. **Headers**:
+>    - `-H 'Content-Type: application/json'`: Indicates that the payload is in JSON format.
+>    - `-H 'X-Api-Key: TEST2'`: Sends an API key for authentication.
+>
+> 3. **Payload**:
+>    - `--data-raw`: Includes the JSON payload to be sent with the `POST` request.
+> 
+> 4. **Piping into `jq`**:
+>    - The output is piped into `jq` to format and colorize the JSON response for easier reading. 
+>
 > Variables enclosed in {{ }} mean that they are whose content has been obtained from the answers of previous calls.
+>
 
-## 1. Create Asset
+> **Actors in this guide**
+> 
+> - **Bob**: data provider, is reachable via `http://dataprovider-controlplane.tx.test`
+> - **Alice**: data consumer, is reachable via `http://dataconsumer-1-controlplane.tx.test`
 
-```
+## Create your first data asset
+
+We will start by creating an asset that represents the data to be shared. The data provider (Bob) uses the **[Management API](https://app.swaggerhub.com/apis/eclipse-edc-bot/management-api)** to define the asset.
+For better understanding, the cURL commands are provided and explained in detail for every step. For nearly every request a response is expected.
+
+### Step 1: Create the asset
+
+Alice, as a data consumer, wants to consume data from Bob. Bob, as a data provider, needs to create an asset for Alice.
+Run the following `curl` command to create the asset:
+
+```bash
 curl -L -X POST 'http://dataprovider-controlplane.tx.test/management/v3/assets' \
--H 'Content-Type: application/json' \
--H 'X-Api-Key: TEST2' \
---data-raw '{
-  "@context": {},
+  -H 'Content-Type: application/json' \
+  -H 'X-Api-Key: TEST2' \
+  --data-raw '{
+    "@context": {
+      "@vocab": "https://w3id.org/edc/v0.0.1/ns/",
+      "edc": "https://w3id.org/edc/v0.0.1/ns/",
+      "tx": "https://w3id.org/tractusx/v0.0.1/ns/",
+      "tx-auth": "https://w3id.org/tractusx/auth/",
+      "cx-policy": "https://w3id.org/catenax/policy/",
+      "odrl": "http://www.w3.org/ns/odrl/2/"
+     },
+    "@id": "200",
+    "properties": {
+      "description": "Product EDC Demo Asset"
+    },
+    "dataAddress": {
+      "@type": "DataAddress",
+      "type": "HttpData",
+      "proxyPath": "true",
+      "proxyMethod": "true",
+      "proxyQueryParams": "true",
+      "proxyBody": "true",
+      "baseUrl": "http://dataprovider-submodelserver.tx.test"
+    }
+  }' | jq
+```
+
+#### Expected output
+
+If successful, the response should look like this:
+
+```json
+{
+  "@type": "IdResponse",
   "@id": "200",
+  "createdAt": 1733150672368,
+  "@context": {
+    "@vocab": "https://w3id.org/edc/v0.0.1/ns/",
+    "edc": "https://w3id.org/edc/v0.0.1/ns/",
+    "tx": "https://w3id.org/tractusx/v0.0.1/ns/",
+    "tx-auth": "https://w3id.org/tractusx/auth/",
+    "cx-policy": "https://w3id.org/catenax/policy/",
+    "odrl": "http://www.w3.org/ns/odrl/2/"
+  }
+}
+```
+
+### Step 2: Validate the asset
+
+Check that the asset was created successfully by running the following for requesting the specific asset with ID 200:
+
+```bash
+curl -L -X GET 'http://dataprovider-controlplane.tx.test/management/v3/assets/200' \
+-H 'X-Api-Key: TEST2' | jq
+```
+
+Alternatively, retrieve all assets:
+
+```bash
+curl -L -X POST 'http://dataprovider-controlplane.tx.test/management/v3/assets/request' \
+-H "x-api-key: TEST2" \
+-H "content-type: application/json" | jq
+```
+
+#### Expected output
+
+The result for the first command shows just the newly created asset:
+
+```json
+{
+  "@id": "200",
+  "@type": "Asset",
   "properties": {
-    "description": "Product EDC Demo Asset"
+    "description": "Product EDC Demo Asset",
+    "id": "200"
   },
   "dataAddress": {
     "@type": "DataAddress",
     "type": "HttpData",
-    "baseUrl": "http://dataprovider-submodelserver.tx.test/200"
-  }
-}'
-```
-
-## 2. Get Asset by ID
-
-To check if the asset is correctly created.
-
-```
-curl -L -X GET 'http://dataprovider-controlplane.tx.test/management/v3/assets/200' \
--H 'X-Api-Key: TEST2'
-```
-
-## 3. Create Policy
-
-```
-curl -L -X POST 'http://dataprovider-controlplane.tx.test/management/v2/policydefinitions' \
--H 'Content-Type: application/json' \
--H 'X-Api-Key: TEST2' \
---data-raw '{
-  "@context": {
-    "odrl": "http://www.w3.org/ns/odrl/2/"
+    "baseUrl": "https://jsonplaceholder.typicode.com/todos/3"
   },
-  "@type": "PolicyDefinitionRequestDto",
-  "@id": "200",
-  "policy": {
-    "@type": "odrl:Set",
-    "odrl:permission": [
-      {
-        "odrl:action": "USE",
-        "odrl:constraint": {
-          "@type": "LogicalConstraint",
-          "odrl:or": [
-            {
-              "@type": "Constraint",
-              "odrl:leftOperand": {
-                "@id": "BusinessPartnerNumber"
-              },
+  "@context": {
+    "@vocab": "https://w3id.org/edc/v0.0.1/ns/",
+    "edc": "https://w3id.org/edc/v0.0.1/ns/",
+    "tx": "https://w3id.org/tractusx/v0.0.1/ns/",
+    "tx-auth": "https://w3id.org/tractusx/auth/",
+    "cx-policy": "https://w3id.org/catenax/policy/",
+    "odrl": "http://www.w3.org/ns/odrl/2/"
+  }
+}
+```
+
+The second request will return all assets. It`s called `request catalog` and will be explained in the next step.
+
+## Request the catalog
+
+Once the asset is created, Alice (the data consumer) can try request a catalog of available (offered) data.
+
+> **Note**
+> 
+> Alice can only see the offered data if a Access Policy was assigned.
+
+### Step 1: Request contract offers
+
+Alice sends a `CatalogRequest` to Bob's connector to discover available assets:
+
+> **Note**
+> 
+> The request can alsop be filtered by an asset ID -> will be explained later
+
+```bash
+curl -L -X POST 'http://dataconsumer-1-controlplane.tx.test/management/v2/catalog/request' \
+  -H 'Content-Type: application/json' \
+  -H 'X-Api-Key: TEST1' \
+  --data-raw '{
+    "@context": {
+      "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+    },
+    "@type": "CatalogRequest",
+    "counterPartyAddress": "http://dataprovider-controlplane.tx.test/api/v1/dsp",
+    "counterPartyId": "BPNL00000003AYRE",
+    "protocol": "dataspace-protocol-http",
+    "querySpec": {
+      "offset": 0,
+      "limit": 50
+    }
+  }' | jq
+```
+
+#### Expected Output
+
+Alice's catalog response will include available assets like this (**but not the newly created asset with ID: 200**):
+
+> **Note**
+> 
+> If the asset is not visible, ensure the **Access Policy** and **Contract Definition** are created on Bob's side.
+
+```json
+{
+  "@id": "be17c3e7-3156-46db-8934-f1ea92d1f2a3",
+  "@type": "dcat:Catalog",
+  "dcat:dataset": [
+    {
+      "@id": "registry-asset",
+      "@type": "dcat:Dataset",
+      "odrl:hasPolicy": {
+        "@id": "MTcxODBlMTAtNmFjNS00NTYzLWE2MTUtNGM1MjQ5ZTUxMTU5:cmVnaXN0cnktYXNzZXQ=:NzE0ODk2YjMtY2VlYy00NmY5LWE5ZTgtY2NiMWI1NGUzOTgy",
+        "@type": "odrl:Set",
+        "odrl:permission": {
+          "odrl:target": "registry-asset",
+          "odrl:action": {
+            "odrl:type": "USE"
+          },
+          "odrl:constraint": {
+            "odrl:or": {
+              "odrl:leftOperand": "PURPOSE",
               "odrl:operator": {
                 "@id": "odrl:eq"
               },
-              "odrl:rightOperand": "BPNL00000003AZQP"
+              "odrl:rightOperand": "ID 3.0 Trace"
             }
-          ]
+          }
+        },
+        "odrl:prohibition": [],
+        "odrl:obligation": [],
+        "odrl:target": "registry-asset"
+      },
+      "dcat:distribution": [
+        {
+          "@type": "dcat:Distribution",
+          "dct:format": {
+            "@id": "HttpProxy"
+          },
+          "dcat:accessService": "49a693e0-835d-457a-99b4-e781f2bd643d"
+        },
+        {
+          "@type": "dcat:Distribution",
+          "dct:format": {
+            "@id": "AmazonS3"
+          },
+          "dcat:accessService": "49a693e0-835d-457a-99b4-e781f2bd643d"
+        }
+      ],
+      "edc:type": "data.core.digitalTwinRegistry",
+      "edc:description": "Digital Twin Registry Endpoint of IRS DEV",
+      "edc:id": "registry-asset"
+    },
+    {
+      "@id": "urn:uuid:dc641d45-95e7-4284-a472-43f30255d0cb",
+      "@type": "dcat:Dataset",
+      "odrl:hasPolicy": {
+        "@id": "MTIzYjJlM2QtNTUxOC00ZWViLWFmMGItNTU5ZTYxZGY3Zjhk:dXJuOnV1aWQ6ZGM2NDFkNDUtOTVlNy00Mjg0LWE0NzItNDNmMzAyNTVkMGNi:YzBhOGFhOTQtNzg4OS00Y2MxLTkzNmMtMWYwMTNkODc3Nzk4",
+        "@type": "odrl:Set",
+        "odrl:permission": {
+          "odrl:target": "urn:uuid:dc641d45-95e7-4284-a472-43f30255d0cb",
+          "odrl:action": {
+            "odrl:type": "USE"
+          },
+          "odrl:constraint": {
+            "odrl:or": {
+              "odrl:leftOperand": "PURPOSE",
+              "odrl:operator": {
+                "@id": "odrl:eq"
+              },
+              "odrl:rightOperand": "ID 3.0 Trace"
+            }
+          }
+        },
+        "odrl:prohibition": [],
+        "odrl:obligation": [],
+        "odrl:target": "urn:uuid:dc641d45-95e7-4284-a472-43f30255d0cb"
+      },
+      "dcat:distribution": [
+        {
+          "@type": "dcat:Distribution",
+          "dct:format": {
+            "@id": "HttpProxy"
+          },
+          "dcat:accessService": "49a693e0-835d-457a-99b4-e781f2bd643d"
+        },
+        {
+          "@type": "dcat:Distribution",
+          "dct:format": {
+            "@id": "AmazonS3"
+          },
+          "dcat:accessService": "49a693e0-835d-457a-99b4-e781f2bd643d"
+        }
+      ],
+      "edc:description": "IRS EDC Test Asset",
+      "edc:id": "urn:uuid:dc641d45-95e7-4284-a472-43f30255d0cb"
+    }
+  ],
+  "dcat:service": {
+    "@id": "49a693e0-835d-457a-99b4-e781f2bd643d",
+    "@type": "dcat:DataService",
+    "dct:terms": "connector",
+    "dct:endpointUrl": "http://dataprovider-controlplane.tx.test/api/v1/dsp"
+  },
+  "edc:participantId": "BPNL00000003AYRE",
+  "@context": {
+    "dct": "http://purl.org/dc/terms/",
+    "tx": "https://w3id.org/tractusx/v0.0.1/ns/",
+    "edc": "https://w3id.org/edc/v0.0.1/ns/",
+    "dcat": "https://www.w3.org/ns/dcat/",
+    "odrl": "http://www.w3.org/ns/odrl/2/",
+    "dspace": "https://w3id.org/dspace/v0.8/"
+  }
+}
+```
+
+## Create a first access policy
+
+Bob creates an **Access Policy** to determine who can view the data offer.
+
+### Step 1: Create the policy
+
+Run this `curl` command:
+
+```bash
+curl -L -X POST 'http://dataprovider-controlplane.tx.test/management/v2/policydefinitions' \
+  -H 'Content-Type: application/json' \
+  -H 'X-Api-Key: TEST2' \
+  --data-raw '{
+    "@context": {
+      "odrl": "http://www.w3.org/ns/odrl/2/"
+    },
+    "@type": "PolicyDefinitionRequestDto",
+    "@id": "200",
+    "policy": {
+      "@type": "odrl:Set",
+      "odrl:permission": [
+        {
+          "odrl:action": "USE",
+          "odrl:constraint": {
+            "@type": "LogicalConstraint",
+            "odrl:or": [
+              {
+                "@type": "Constraint",
+                "odrl:leftOperand": {
+                  "@id": "BusinessPartnerNumber"
+                },
+                "odrl:operator": {
+                  "@id": "odrl:eq"
+                },
+                "odrl:rightOperand": "BPNL00000003AZQP"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }' | jq
+```
+
+In this case a **Access Policy** is created. The assigned asset will only be visible as a data offer for the Business Partner Number `BPNL00000003AZQP`.
+
+#### Expected Output
+
+The policy was successfully created, if the response is something like this
+
+```json
+{
+  "@type": "IdResponse",
+  "@id": "200",
+  "createdAt": 1732640748595,
+  "@context": {
+    "@vocab": "https://w3id.org/edc/v0.0.1/ns/",
+    "edc": "https://w3id.org/edc/v0.0.1/ns/",
+    "tx": "https://w3id.org/tractusx/v0.0.1/ns/",
+    "tx-auth": "https://w3id.org/tractusx/auth/",
+    "cx-policy": "https://w3id.org/catenax/policy/",
+    "odrl": "http://www.w3.org/ns/odrl/2/"
+  }
+}
+```
+
+### Step 2: Request catalog - second try
+
+Now that Bob created an access policy, Alice can once again try to access Bob's offer by running this `curl`.
+
+```shell
+curl -L -X POST 'http://dataconsumer-1-controlplane.tx.test/management/v2/catalog/request' \
+  -H 'Content-Type: application/json' \
+  -H 'X-Api-Key: TEST1' \
+  --data-raw '{
+    "@context": {
+      "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+    },
+    "@type": "CatalogRequest",
+    "counterPartyAddress": "http://dataprovider-controlplane.tx.test/api/v1/dsp",
+    "counterPartyId": "BPNL00000003AYRE",
+    "protocol": "dataspace-protocol-http",
+    "querySpec": {
+      "offset": 0,
+      "limit": 50
+    }
+  }' | jq
+```
+  
+#### Expected Output
+
+Since the asset is still not visible, the response will be the same as before. This is expected, as the asset is not yet linked to the policy.
+
+> **Note**
+> 
+> Once again Alice cannot find the data offer. This is by design and to be expected since Bob has only created an asset and a policy definition. An asset and a policy can not be displayed to Alice as a consumer without a contract definition.
+> **For providing data, a contract definition must be created on the provider side. This must always contain an asset, an access policy, and a contract policy.**
+>
+> Contract definitions state how assets and policies are linked together. Contract definitions express under what conditions an asset is published in a data space. Those conditions are comprised of a contract policy and an access policy. Those policies are referenced by ID, that means they must already exist in the policy store before creating the contract definition.
+> 
+> - **Access policy:** determines whether or not a particular consumer can see an asset in the provider's catalog. For example, we may want to restrict certain assets such that only selected consumers from a list of selected partners can access the asset. This can be done using a unique identifier such as the Business Partner Number (BPN). Other data space participants than those whose BPN is listed in the access policy wouldn't even be able to see the asset in the catalog.
+> - **Contract policy:** determines the conditions for initiating a contract negotiation for a particular asset. Note that this does not automatically guarantee the successful creation of a contract, it merely expresses the eligibility to start the negotiation.
+> 
+> Find additional information on transferring data in the [Developer's Handbook](https://github.com/eclipse-edc/docs/blob/main/developer/handbook.md).
+
+## Define a contract definition
+
+Alice still cannot see the asset because Bob hasn't created a **Contract Definition**. Contract definitions link assets and policies to define usage terms.
+
+### Step 1: Create the contract definition
+
+First of all run this `curl` command to check if the policy is created correctly:
+
+```bash
+curl -L -X GET 'http://dataprovider-controlplane.tx.test/management/v2/policydefinitions/200' \
+-H 'X-Api-Key: TEST2' | jq
+```
+
+The policy with ID: 200 was successfully created, if the response is something like this
+
+```json
+{
+  "@id": "200",
+  "@type": "PolicyDefinition",
+  "createdAt": 1732640748595,
+  "policy": {
+    "@id": "d7f2161b-1670-4461-ab36-e5aeefcab2e9",
+    "@type": "odrl:Set",
+    "odrl:permission": {
+      "odrl:action": {
+        "@id": "USE"
+      },
+      "odrl:constraint": {
+        "odrl:or": {
+          "odrl:leftOperand": {
+            "@id": "BusinessPartnerNumber"
+          },
+          "odrl:operator": {
+            "@id": "odrl:eq"
+          },
+          "odrl:rightOperand": "BPNL00000003AZQP"
         }
       }
-    ]
+    },
+    "odrl:prohibition": [],
+    "odrl:obligation": []
+  },
+  "@context": {
+    "@vocab": "https://w3id.org/edc/v0.0.1/ns/",
+    "edc": "https://w3id.org/edc/v0.0.1/ns/",
+    "tx": "https://w3id.org/tractusx/v0.0.1/ns/",
+    "tx-auth": "https://w3id.org/tractusx/auth/",
+    "cx-policy": "https://w3id.org/catenax/policy/",
+    "odrl": "http://www.w3.org/ns/odrl/2/"
   }
-}'
+}
 ```
 
-## 4. Get Policies by ID
+Run this `curl` command to create a contract definition including the asset and the policies you have created:
 
-To check if the Policies are correctly created.
-```
-curl -L -X GET 'http://dataprovider-controlplane.tx.test/management/v2/policydefinitions/200' \
--H 'X-Api-Key: TEST2'
-```
-
-## 5. Create Contract Definition
-
-```
+```bash
 curl -L -X POST 'http://dataprovider-controlplane.tx.test/management/v2/contractdefinitions' \
--H 'Content-Type: application/json' \
--H 'X-Api-Key: TEST2' \
---data-raw '{
-  "@context": {},
+  -H 'Content-Type: application/json' \
+  -H 'X-Api-Key: TEST2' \
+  --data-raw '{
+    "@context": {},
+    "@id": "200",
+    "@type": "ContractDefinition",
+    "accessPolicyId": "200",
+    "contractPolicyId": "200",
+    "assetsSelector": {
+      "@type": "CriterionDto",
+      "operandLeft": "https://w3id.org/edc/v0.0.1/ns/id",
+      "operator": "=",
+      "operandRight": "200"
+    }
+  }' | jq
+```
+
+#### Expected Output
+
+```json
+{
+  "@type": "IdResponse",
   "@id": "200",
-  "@type": "ContractDefinition",
-  "accessPolicyId": "200",
-  "contractPolicyId": "200",
-  "assetsSelector": {
-    "@type": "CriterionDto",
-    "operandLeft": "https://w3id.org/edc/v0.0.1/ns/id",
-    "operator": "=",
-    "operandRight": "200"
+  "createdAt": 1732698850793,
+  "@context": {
+    "@vocab": "https://w3id.org/edc/v0.0.1/ns/",
+    "edc": "https://w3id.org/edc/v0.0.1/ns/",
+    "tx": "https://w3id.org/tractusx/v0.0.1/ns/",
+    "tx-auth": "https://w3id.org/tractusx/auth/",
+    "cx-policy": "https://w3id.org/catenax/policy/",
+    "odrl": "http://www.w3.org/ns/odrl/2/"
   }
-}'
+}
 ```
 
-## 6. Get Contract Definition by ID
+## Verify data availability
 
-To check if the Contract Definition is correctly executed
-```
-curl -L -X GET 'http://dataprovider-controlplane.tx.test/management/v2/contractdefinitions/200' \
--H 'X-Api-Key: TEST2'
+Alice re-requests the catalog. This time, she should see Bob's asset in the catalog:
+
+> **Note**
+> 
+> In this call, the `filterExpression` is used to filter the catalog by the asset ID. This is optional and can be omitted.
+
+```bash
+curl -L -X POST 'http://dataconsumer-1-controlplane.tx.test/management/v2/catalog/request' \
+  -H 'Content-Type: application/json' \
+  -H 'X-Api-Key: TEST1' \
+  --data-raw '{
+    "@context": {
+      "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+    },
+    "@type": "CatalogRequest",
+    "counterPartyAddress": "http://dataprovider-controlplane.tx.test/api/v1/dsp",
+    "counterPartyId": "BPNL00000003AYRE",
+    "protocol": "dataspace-protocol-http",
+        "querySpec": {
+        "filterExpression": [
+            {
+                "operandLeft": "https://w3id.org/edc/v0.0.1/ns/id",
+                "operator": "=",
+                "operandRight": "200"
+            } 
+        ] 
+    }
+  }' | jq
 ```
 
-## NOTICE
+### Expected Output
+
+```json
+{
+  "@id": "ad6b2272-a131-4d75-9efd-0c7529d1109f",
+  "@type": "dcat:Catalog",
+  "dspace:participantId": "BPNL00000003AYRE",
+  "dcat:dataset": {
+    "@id": "200",
+    "@type": "dcat:Dataset",
+    "odrl:hasPolicy": {
+      "@id": "MjAw:MjAw:YzNlOWVjYzEtMDcwNS00YWI1LThhM2UtOWNmYTA5NTg2ZWU4",
+      "@type": "odrl:Offer",
+      "odrl:permission": {
+        "odrl:action": {
+          "odrl:type": "USE"
+        },
+        "odrl:constraint": {
+          "odrl:or": {
+            "odrl:leftOperand": "BusinessPartnerNumber",
+            "odrl:operator": {
+              "@id": "odrl:eq"
+            },
+            "odrl:rightOperand": "BPNL00000003AZQP"
+          }
+        }
+      },
+      "odrl:prohibition": [],
+      "odrl:obligation": []
+    },
+    "dcat:distribution": [
+      {
+        "@type": "dcat:Distribution",
+        "dct:format": {
+          "@id": "AzureStorage-PUSH"
+        },
+        "dcat:accessService": {
+          "@id": "ed228dd5-d1e6-45be-84be-20ba27829e50",
+          "@type": "dcat:DataService",
+          "dcat:endpointDescription": "dspace:connector",
+          "dcat:endpointUrl": "http://dataprovider-controlplane.tx.test/api/v1/dsp",
+          "dct:terms": "dspace:connector",
+          "dct:endpointUrl": "http://dataprovider-controlplane.tx.test/api/v1/dsp"
+        }
+      },
+      {
+        "@type": "dcat:Distribution",
+        "dct:format": {
+          "@id": "HttpData-PULL"
+        },
+        "dcat:accessService": {
+          "@id": "ed228dd5-d1e6-45be-84be-20ba27829e50",
+          "@type": "dcat:DataService",
+          "dcat:endpointDescription": "dspace:connector",
+          "dcat:endpointUrl": "http://dataprovider-controlplane.tx.test/api/v1/dsp",
+          "dct:terms": "dspace:connector",
+          "dct:endpointUrl": "http://dataprovider-controlplane.tx.test/api/v1/dsp"
+        }
+      },
+      {
+        "@type": "dcat:Distribution",
+        "dct:format": {
+          "@id": "HttpData-PUSH"
+        },
+        "dcat:accessService": {
+          "@id": "ed228dd5-d1e6-45be-84be-20ba27829e50",
+          "@type": "dcat:DataService",
+          "dcat:endpointDescription": "dspace:connector",
+          "dcat:endpointUrl": "http://dataprovider-controlplane.tx.test/api/v1/dsp",
+          "dct:terms": "dspace:connector",
+          "dct:endpointUrl": "http://dataprovider-controlplane.tx.test/api/v1/dsp"
+        }
+      },
+      {
+        "@type": "dcat:Distribution",
+        "dct:format": {
+          "@id": "AmazonS3-PUSH"
+        },
+        "dcat:accessService": {
+          "@id": "ed228dd5-d1e6-45be-84be-20ba27829e50",
+          "@type": "dcat:DataService",
+          "dcat:endpointDescription": "dspace:connector",
+          "dcat:endpointUrl": "http://dataprovider-controlplane.tx.test/api/v1/dsp",
+          "dct:terms": "dspace:connector",
+          "dct:endpointUrl": "http://dataprovider-controlplane.tx.test/api/v1/dsp"
+        }
+      }
+    ],
+    "description": "Product EDC Demo Asset",
+    "id": "200"
+  },
+  "dcat:service": {
+    "@id": "ed228dd5-d1e6-45be-84be-20ba27829e50",
+    "@type": "dcat:DataService",
+    "dcat:endpointDescription": "dspace:connector",
+    "dcat:endpointUrl": "http://dataprovider-controlplane.tx.test/api/v1/dsp",
+    "dct:terms": "dspace:connector",
+    "dct:endpointUrl": "http://dataprovider-controlplane.tx.test/api/v1/dsp"
+  },
+  "participantId": "BPNL00000003AYRE",
+  "@context": {
+    "@vocab": "https://w3id.org/edc/v0.0.1/ns/",
+    "edc": "https://w3id.org/edc/v0.0.1/ns/",
+    "tx": "https://w3id.org/tractusx/v0.0.1/ns/",
+    "tx-auth": "https://w3id.org/tractusx/auth/",
+    "cx-policy": "https://w3id.org/catenax/policy/",
+    "dcat": "http://www.w3.org/ns/dcat#",
+    "dct": "http://purl.org/dc/terms/",
+    "odrl": "http://www.w3.org/ns/odrl/2/",
+    "dspace": "https://w3id.org/dspace/v0.8/"
+  }
+}
+```
+
+> **Congratulations**
+> 
+> Finally Alice can see the Contract Offer from Bob. Congratulations on yor first successful offering of data in your own data space!
+
+## Notice
 
 This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
 

--- a/docs/user/guides/data-exchange/provide-data.md
+++ b/docs/user/guides/data-exchange/provide-data.md
@@ -131,7 +131,7 @@ The result for the first command shows just the newly created asset:
 }
 ```
 
-The second request will return all assets. It`s called `request catalog` and will be explained in the next step.
+The second request will return all assets. It's called `request catalog` and will be explained in the next step.
 
 ## Request the catalog
 

--- a/docs/user/setup/README.md
+++ b/docs/user/setup/README.md
@@ -67,7 +67,7 @@ After starting Minikube or Docker Desktop Kubernetes, verify the cluster setup:
 
 Use tools like the Minikube dashboard (or [Open Lens](https://k8slens.dev/)) to visualize your cluster and deployed components.
 
-For networking setup, proceed to the [Network Setup Guide](../network/setup).
+For networking setup, proceed to the [Network Setup Guide](../network/README.md).
 
 ## NOTICE
 


### PR DESCRIPTION
## Description

This PR adds some improvements, restructuring within the data exchange documentation. It also adds requests and expected responses to get a more in-depth understanding of the flow. The currently documented flow was tested multiple times.

@dvg36 would be cool to test it again, just to be sure!!! I think after this, we are well-prepared for the Tractus-X Community Days. ;)

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
