### PR TITLE
docs(kubernetes setup): add support for people without docker desktop on macOS

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@ The following table links you to the respective documentations.
     - [TLS (Optional)](user/network/tls)
 - [Installation](user/installation/README.md)
     - [Released Charts](user/installation/released-charts.md)
-    - [Local Charts](user/installation/local-charts.md)
+    - [Local Charts](user/installation/local-repository.md)
     - [Uninstallation](user/installation/unREADME.md)
 - [Guides](user/guides)
     - [Data Exchange](user/guides/data-exchange.md)

--- a/docs/user/network/README.md
+++ b/docs/user/network/README.md
@@ -56,6 +56,12 @@ The following ingresses are configured and available:
 
 Proper DNS resolution is required to map local domain names to the Minikube IP address. Follow the steps for your operating system:
 
+- [Linus](#linux)
+- [mac](#macos)
+  - [using Minikube](#option-1-minikube)
+  - [using K3s](#option-2-k3s)
+- [Windows](#windows)
+
 ### Linux
 
 1. Identify your DNS resolver by checking the contents of `/etc/resolv.conf`.
@@ -120,7 +126,11 @@ Proper DNS resolution is required to map local domain names to the Minikube IP a
 
 ### macOS
 
-#### Option 1: minikube
+Please refer to [option 1](#option-1-minikube) for the dns setup in case you're using Minikube, which is the most tested and therefore the recommended option.
+[Option 2](#option-2-k3s) outlines the dns setup in case you're using K3s.
+
+#### Option 1: Minikube
+
 1. Create a resolver configuration for `.test` domains:
    ```bash
    sudo mkdir -p /etc/resolver
@@ -141,23 +151,27 @@ Proper DNS resolution is required to map local domain names to the Minikube IP a
 
    We also recommend to execute the usage example after install to check proper setup.
 
-
 3. Test DNS resolution by pinging one of the configured hostnames.
 
-#### Option 2: k3s
+#### Option 2: K3s
+
 Here the easiest solution is the configuration via hosts:
 
 1. add [the hosts](#hosts-file-configuration-fallback) to your `/etc/hosts` file of your **Mac**, use `127.0.0.1` to replace the placeholder `<MINIKUBE_IP>`
 
 2. add [the hosts](#hosts-file-configuration-fallback) to your `/etc/hosts` file of your **lima vm**, use `192.168.5.15` to replace the placeholder `<MINIKUBE_IP>`
+
    ```bash
-   #to login to your limavm 
+   #to login to your limavm
    limactl shell k3s
    ```
+
 3. add [the hosts](#hosts-file-configuration-fallback) to your coredns configuration of your **k3s-cluster**, use `192.168.5.15` to replace the placeholder `<MINIKUBE_IP>`
+
    ```bash
    kubectl edit cm coredns -n kube-system
    ```
+
    ```yaml
    apiVersion: v1
    data:
@@ -178,6 +192,7 @@ Here the easiest solution is the configuration via hosts:
             fallthrough
          }
    ```
+
    > **Note**
    > If you do this step, after you already deployed the helm charts, make sure to  restart your java backend pods (controlplane and dataplane) to refresh their dns resolution.
    > To make this change permanent in your vm, make sure to update `/var/lib/rancher/k3s/server/manifests/coredns.yaml` in the install script of your vm template

--- a/docs/user/setup/README.md
+++ b/docs/user/setup/README.md
@@ -12,57 +12,80 @@ The above specifications are the minimum requirements for a local development se
 
 ## Supported Platforms
 
+> **Note**
+> It is recommended to use Linux or macOS because those two are the most tested platforms with the umbrella.
+
+- [Linux](#1-linux)
+- [macOS](#2-macos)
+  - [using Minikube with Docker Desktop](#option-1-docker-desktop-available)
+  - [using K3s with lima](#option-2-no-docker-desktop-available)
+- [Windows](#2-macos)
+
 ### 1. Linux
 
-> **Note**
-> As already mentioned, this is the recommendation, since these two variants are the most tested ones.
-
 Start a Minikube cluster with the following command:
-```bash
-minikube start --cpus=4 --memory=6gb
-```
-### 2. Mac
 
-#### Option 1: docker desktop available
-
-Start a Minikube cluster with the following command:
 ```bash
 minikube start --cpus=4 --memory=6gb
 ```
 
-#### Option 2: no docker desktop available (license reasons or whatever)
+### 2. macOS
 
-In this case, a tested way to setup your local kubernetes cluster is with [lima](https://lima-vm.io/) and [k3s](https://k3s.io/):
+Please refer to [option 1](#option-1-docker-desktop-available) with Minikube for the cluster setup in case you're using Docker Desktop, which is the most tested and therefore the recommended option.
+[Option 2](#option-2-no-docker-desktop-available) outlines [lima](https://lima-vm.io/) with K3s as cluster option in case Docker Desktop isn't available.
+
+#### Option 1: Docker Desktop available
+
+Start a Minikube cluster with the following command:
+
+```bash
+minikube start --cpus=4 --memory=6gb
+```
+
+#### Option 2: No docker desktop available
+
+In this case, a tested way to setup your local kubernetes cluster is with [lima](https://lima-vm.io/) and [K3s](https://k3s.io/):
+
 ```bash
 brew install lima
 
 #as we are using a vm template, we download it first
 curl -O https://raw.githubusercontent.com/lima-vm/lima/refs/heads/master/templates/k3s.yaml
 ```
+
 then we need to modify it a little, to propagate your proxysettings, add the following:
+
 ```yaml
 propagateProxyEnv: true
 ```
+
 if you for example need ca-certificates because of a corporate proxy then add the following:
+
 ```yaml
 caCerts:
   removeDefaults: null
   files:
   - /path/to/your/certificates/ca-certificates.crt
 ```
+
 to adjust the size of your vm add:
+
 ```yaml
 cpus: 6
 memory: 8GiB
 ```
+
 to support also non-arm images in your cluster add:
+
 ```yaml
 rosetta:
   enabled: true
   binfmt: true
 vmType: vz
 ```
-as k3s comes with traefik by default and these helm charts are for NGINX ingress, we need to modify the install script (starting line 39) a [little](https://www.suse.com/support/kb/doc/?id=000020082):
+
+as K3s comes with traefik by default and these helm charts are for NGINX ingress, we need to modify the install script (starting line 39) a [little](https://www.suse.com/support/kb/doc/?id=000020082):
+
 ```yaml
 - mode: system
   script: |
@@ -106,7 +129,9 @@ as k3s comes with traefik by default and these helm charts are for NGINX ingress
             use-forwarded-headers: "true"
     EOF
 ```
+
 after this you can start your vm:
+
 ```bash
 #prepare no_proxy for the testdomains
 export no_proxy=$no_proxy,192.168.5.15,.test

--- a/docs/user/setup/README.md
+++ b/docs/user/setup/README.md
@@ -12,7 +12,7 @@ The above specifications are the minimum requirements for a local development se
 
 ## Supported Platforms
 
-### 1. Linux & Mac
+### 1. Linux
 
 > **Note**
 > As already mentioned, this is the recommendation, since these two variants are the most tested ones.
@@ -21,8 +21,104 @@ Start a Minikube cluster with the following command:
 ```bash
 minikube start --cpus=4 --memory=6gb
 ```
+### 2. Mac
 
-### 2. Windows
+#### Option 1: docker desktop available
+
+Start a Minikube cluster with the following command:
+```bash
+minikube start --cpus=4 --memory=6gb
+```
+
+#### Option 2: no docker desktop available (license reasons or whatever)
+
+In this case, a tested way to setup your local kubernetes cluster is with [lima](https://lima-vm.io/) and [k3s](https://k3s.io/):
+```bash
+brew install lima
+
+#as we are using a vm template, we download it first
+curl -O https://raw.githubusercontent.com/lima-vm/lima/refs/heads/master/templates/k3s.yaml
+```
+then we need to modify it a little, to propagate your proxysettings, add the following:
+```yaml
+propagateProxyEnv: true
+```
+if you for example need ca-certificates because of a corporate proxy then add the following:
+```yaml
+caCerts:
+  removeDefaults: null
+  files:
+  - /path/to/your/certificates/ca-certificates.crt
+```
+to adjust the size of your vm add:
+```yaml
+cpus: 6
+memory: 8GiB
+```
+to support also non-arm images in your cluster add:
+```yaml
+rosetta:
+  enabled: true
+  binfmt: true
+vmType: vz
+```
+as k3s comes with traefik by default and these helm charts are for NGINX ingress, we need to modify the install script (starting line 39) a [little](https://www.suse.com/support/kb/doc/?id=000020082):
+```yaml
+- mode: system
+  script: |
+    #!/bin/bash
+    set -eux -o pipefail
+    export K3S_KUBECONFIG_MODE="644"
+    curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="--disable traefik" sudo sh -
+    cat >/var/lib/rancher/k3s/server/manifests/ingress-nginx.yaml <<EOF
+    apiVersion: v1
+    kind: Namespace
+    metadata:
+      name: ingress-nginx
+    ---
+    apiVersion: helm.cattle.io/v1
+    kind: HelmChart
+    metadata:
+      name: ingress-nginx
+      namespace: kube-system
+    spec:
+      chart: ingress-nginx
+      repo: https://kubernetes.github.io/ingress-nginx
+      targetNamespace: ingress-nginx
+      version: v4.11.2
+      set:
+      valuesContent: |-
+        fullnameOverride: ingress-nginx
+        controller:
+          kind: DaemonSet
+          hostNetwork: true
+          hostPort:
+            enabled: true
+          service:
+            enabled: false
+          publishService:
+            enabled: false
+          metrics:
+            enabled: true
+            serviceMonitor:
+              enabled: false
+          config:
+            use-forwarded-headers: "true"
+    EOF
+```
+after this you can start your vm:
+```bash
+#prepare no_proxy for the testdomains
+export no_proxy=$no_proxy,192.168.5.15,.test
+
+#start the vm
+limactl start k3s.yaml
+
+#configure kubectl
+export KUBECONFIG="/Users/YOURUSER/.lima/docker/copied-from-guest/kubeconfig.yaml"
+```
+
+### 3. Windows
 
 For DNS resolution to work correctly on Windows, you have two options:
 


### PR DESCRIPTION
## Description
This PR extends the setup and network documentation with a way to go for people who have no access to docker desktop because of license issues in their companies (or whatever reason) on macOS. It also supports more complicated company setups with proxys and custom certificate chains.  The currently documented flow was tested multiple times.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
