### PR TITLE
docs: fix incorrect iatp-mock directory

### DIFF
--- a/docs/user/setup/iatp-mock.md
+++ b/docs/user/setup/iatp-mock.md
@@ -10,7 +10,7 @@ The IATP Mock requires a compatible Docker image. Follow these steps to build th
    Clone the Umbrella Chart repository and navigate to the IATP Mock directory:
    ```bash
    git clone https://github.com/eclipse-tractusx/tractus-x-umbrella.git
-   cd tractus-x-umbrella/charts/umbrella/charts/iatpmock
+   cd tractus-x-umbrella/iatp-mock/
    ```
 
 2. **Build the Docker Image**:


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->
#184 
Fix incorrect iatp-mock directory in [doc](https://github.com/eclipse-tractusx/tractus-x-umbrella/blob/main/docs/user/setup/iatp-mock.md#precondition-build-the-iatp-mock-docker-image)

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
