### PR TITLE
fix: BPN Creation Gets Stuck During Portal Onboarding

### DIFF
--- a/charts/umbrella/Chart.yaml
+++ b/charts/umbrella/Chart.yaml
@@ -28,7 +28,7 @@ sources:
   - https://github.com/eclipse-tractusx/tractus-x-umbrella
 
 type: application
-version: 2.1.0
+version: 2.1.1
 
 # when adding or updating versions of dependencies, also update list under /docs/user/installation/README.md
 dependencies:

--- a/charts/umbrella/values.yaml
+++ b/charts/umbrella/values.yaml
@@ -46,7 +46,7 @@ portal:
   dimWrapper:
     baseAddress: "http://ssi-dim-wallet-stub.tx.test"
     apiPath: "/api/dim"
-    tokenAddress: "http://someiam.tx.test/realms/example/protocol/openid-connect/token"
+    tokenAddress: "http://ssi-dim-wallet-stub.tx.test/oauth/token"
   decentralIdentityManagementAuthAddress: "http://ssi-dim-wallet-stub.tx.test/api/sts"
   sdfactoryAddress: "http://sdfactory.tx.test"
   clearinghouseAddress: "http://validation.tx.test"
@@ -928,11 +928,6 @@ bpdm:
         bpn:
           # This Gate has no owner restriction as other companies can write into the Gate under their own tenant
           owner-bpn-l:
-        tasks:
-          creation:
-            fromSharingMember:
-              # Portal needs to set uploaded business partner data as ready to be shared by itself (disables setting it automatically as ready)
-              starts-as-ready: false
         security:
           # App's API is authenticated over Central-IDP
           auth-server-url: "http://centralidp.tx.test/auth"


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->
This PR resolves the issue where the participant onboarding process in the Portal gets stuck at the BPN creation step, preventing the Wallet creation step from proceeding.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->
Fixes #209 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
