### PR TITLE
docs: add Identity wallet creation step to the participant onboarding

### DIFF
--- a/docs/user/guides/portal-usage.md
+++ b/docs/user/guides/portal-usage.md
@@ -112,6 +112,9 @@ The Portal allows onboarding participants by inviting them to join the network. 
 > **Note**
 > Since the onboarding process requires the [Clearinghouse](https://github.com/eclipse-tractusx/portal-assets/blob/v2.1.0/docs/developer/Technical%20Documentation/Interface%20Contracts/Clearinghouse.md) to work properly, but ClearingHouse currently isn't available as a FOSS application you can skip the step with the following SQL Script which must be executed against the portal database.
 
+> **Note**
+> The Identity wallet is currently not working due to the issue in the portal backend described [here](https://github.com/eclipse-tractusx/portal/issues/499). The below sql statement supports the current workaround until the issue is resolved.
+
 ```sql
 WITH applications AS (
     SELECT distinct ca.id as Id, ca.checklist_process_id as ChecklistId


### PR DESCRIPTION
**The PR #208 was no more valid due to the declining of an ECA agreement**

## Description

The wallet creation step was getting failed during the participant onboarding [here](https://github.com/eclipse-tractusx/tractus-x-umbrella/blob/main/docs/user/guides/portal-usage.md#performing-participant-onboarding), .
In the original portal values, the `didDocumentPath` is set to `/api/administration/staticdata/did`.

Documented the step to set the endpoint to an empty string in the ssi-dim-wallet-stub values file.

https://github.com/eclipse-tractusx/tractus-x-umbrella/issues/197#issuecomment-2615382083