### PR TITLE
fix(Observability): fixed alignment of prometheus port for JVM metrics

### DIFF
--- a/charts/umbrella/Chart.yaml
+++ b/charts/umbrella/Chart.yaml
@@ -28,7 +28,7 @@ sources:
   - https://github.com/eclipse-tractusx/tractus-x-umbrella
 
 type: application
-version: 2.12.0
+version: 2.12.1
 
 # when adding or updating versions of dependencies, also update list under /docs/user/installation/README.md
 dependencies:

--- a/charts/umbrella/values-adopter-data-exchange-observability.yaml
+++ b/charts/umbrella/values-adopter-data-exchange-observability.yaml
@@ -39,6 +39,7 @@ dataconsumerOne:
         otel.exporter.jaeger.endpoint=http://umbrella-jaeger-collector.umbrella:4318
         otel.metrics.exporter=prometheus
         otel.metrics.protocol=http/protobuf
+        otel.exporter.prometheus.port=9090
         edc.metrics.enabled=true
         edc.metrics.system.enabled=true
         otel.instrumentation.micrometer.enabled=true
@@ -55,6 +56,7 @@ dataconsumerOne:
         otel.exporter.jaeger.endpoint=http://umbrella-jaeger-collector.umbrella:4318
         otel.metrics.exporter=prometheus
         otel.metrics.protocol=http/protobuf
+        otel.exporter.prometheus.port=9090
         edc.metrics.enabled=true
         edc.metrics.system.enabled=true
         otel.instrumentation.micrometer.enabled=true
@@ -80,6 +82,7 @@ tx-data-provider:
         otel.exporter.jaeger.endpoint=http://umbrella-jaeger-collector.umbrella:4318
         otel.metrics.exporter=prometheus
         otel.metrics.protocol=http/protobuf
+        otel.exporter.prometheus.port=9090
         edc.metrics.enabled=true
         edc.metrics.system.enabled=true
         otel.instrumentation.micrometer.enabled=true
@@ -95,6 +98,7 @@ tx-data-provider:
         otel.exporter.jaeger.endpoint=http://umbrella-jaeger-collector.umbrella:4318
         otel.metrics.exporter=prometheus
         otel.metrics.protocol=http/protobuf
+        otel.exporter.prometheus.port=9090
         edc.metrics.enabled=true
         edc.metrics.system.enabled=true
         otel.instrumentation.micrometer.enabled=true


### PR DESCRIPTION
## Description
Fixes scraping of prometheus JVM metrics due to pointing to default 9464 port, instead of tractusx-edc's 9090.

Outcome of [following discussion](https://github.com/eclipse-tractusx/tractusx-edc/issues/1905#issuecomment-2829829970)
## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
