### PR TITLE
fix: align issuer configuration

### DIFF
--- a/charts/umbrella/Chart.yaml
+++ b/charts/umbrella/Chart.yaml
@@ -28,7 +28,7 @@ sources:
   - https://github.com/eclipse-tractusx/tractus-x-umbrella
 
 type: application
-version: 2.14.0
+version: 2.14.1
 
 # when adding or updating versions of dependencies, also update list under /docs/user/installation/README.md
 dependencies:

--- a/charts/umbrella/values.yaml
+++ b/charts/umbrella/values.yaml
@@ -827,6 +827,7 @@ ssi-credential-issuer:
       default: "Debug"
   postgresql:
     enabled: true
+    nameOverride: issuer-postgresql
     architecture: standalone
     primary:
       persistence:

--- a/charts/umbrella/values.yaml
+++ b/charts/umbrella/values.yaml
@@ -780,6 +780,7 @@ selfdescription:
 
 ssi-credential-issuer:
   enabled: false
+  replicaCount: 1
   portalBackendAddress: "http://portal-backend.tx.test"
   walletAddress: "http://ssi-dim-wallet-stub.tx.test"
   walletTokenAddress: "http://ssi-dim-wallet-stub.tx.test/oauth/token"
@@ -812,8 +813,6 @@ ssi-credential-issuer:
       clientSecret: "changeme"
     logging:
       default: "Debug"
-    processIdentity:
-      identityId: ac1cf001-7fbc-1f2f-817f-bce058020006
     wallet:
       # -- Provide wallet client-id from CX IAM centralidp.
       # You must specify the technical user with the required roles for the interaction with the managed-identity-wallet
@@ -834,10 +833,9 @@ ssi-credential-issuer:
         enabled: false
     auth:
       # -- Password for the root username 'postgres'. Secret-key 'postgres-password'.
-      postgrespassword: "rootissuerpassword"
+      postgrespassword: "dbpasswordissuer"
       # -- Password for the non-root username 'issuer'. Secret-key 'password'.
-      password: "issuerpassword"
-
+      password: "dbpasswordissuer"
   centralidp:
     # -- Provide centralidp base address (CX IAM), without trailing '/auth'.
     address: "http://centralidp.tx.test"

--- a/docs/user/guides/database-access.md
+++ b/docs/user/guides/database-access.md
@@ -50,16 +50,18 @@ postgres
 
 ### Database Connection Details
 
-| Component         | Host                              |Password                   |
-|-------------------|-----------------------------------|---------------------------|
-| Portal            | `umbrella-portal-backend-postgresql` |`dbpasswordportal`         |
-| CentralIdP        | `umbrella-centralidp-postgresql`    |`dbpasswordcentralidp`     |
-| SharedIdP         | `umbrella-sharedidp-postgresql`    |`dbpasswordsharedidp`      |
-| MIW               | `umbrella-miw-postgres`            |`dbpasswordmiw`            |
-| Data Provider     | `umbrella-dataprovider-db`         |`dbpasswordtxdataprovider` |
-| Data Consumer 1   | `umbrella-dataconsumer-1-db`       |`dbpassworddataconsumerone`|
-| Data Consumer 2   | `umbrella-dataconsumer-2-db`       |`dbpassworddataconsumertwo`|
-| BPDM              | `umbrella-bpdm-postgres`           |`dbpasswordbpdm`           |
+| Component              | Host                                 |Password                   |
+|------------------------|--------------------------------------|---------------------------|
+| Portal                 | `umbrella-portal-backend-postgresql` |`dbpasswordportal`         |
+| CentralIdP             | `umbrella-centralidp-postgresql`     |`dbpasswordcentralidp`     |
+| SharedIdP              | `umbrella-sharedidp-postgresql`      |`dbpasswordsharedidp`      |
+| SSI Credential Issuer  | `umbrella-issuer-postgresql`         |`dbpasswordissuer`         |
+| Data Provider          | `umbrella-dataprovider-db`           |`dbpasswordtxdataprovider` |
+| Data Consumer 1        | `umbrella-dataconsumer-1-db`         |`dbpassworddataconsumerone`|
+| Data Consumer 2        | `umbrella-dataconsumer-2-db`         |`dbpassworddataconsumertwo`|
+| BPDM                   | `umbrella-bpdm-postgres`             |`dbpasswordbpdm`           |
+
+For connection details not listed in this table, please refer to the [values.yaml file of the umbrella chart](/charts/umbrella/values.yaml).
 
 ## Verifying Database Access
 


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description

with other integrated configuration:
-  replica count to 1 to not waste resources
- processIdentity can fall back to values file from issuer chart
- password pattern of other postgres dependencies
- add nameOverride for issuer postgres dependency
- update db access docs

noticed in the course of checking #273

<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
