### PR TITLE
docs: add section '3.1. Windows with Ubuntu WSL' to Cluster Setup 

### DIFF
--- a/docs/user/setup/README.md
+++ b/docs/user/setup/README.md
@@ -196,6 +196,76 @@ After starting Minikube or Docker Desktop Kubernetes, verify the cluster setup:
   minikube dashboard
   ```
 
+### 3.1 Windows with WSL
+
+Follow these steps when running Ubuntu 22.04 LTS in WSL:
+
+```bash
+# Install kubectl
+curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+chmod +x ./kubectl
+sudo mv ./kubectl /usr/local/bin/kubectl
+kubectl version
+
+# Install Docker
+sudo apt-get install -y ca-certificates curl gnupg lsb-release
+sudo mkdir -p /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+  $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+sudo apt-get update
+sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
+sudo systemctl status docker
+sudo groupadd docker
+sudo usermod -aG docker $USER && newgrp docker
+sudo systemctl enable docker
+
+# Install cri-dockerd
+wget https://github.com/Mirantis/cri-dockerd/releases/download/v0.3.15/cri-dockerd_0.3.15.3-0.ubuntu-jammy_amd64.deb
+sudo dpkg -i cri-dockerd_0.3.15.3-0.ubuntu-jammy_amd64.deb
+
+# Install conntrack
+sudo apt-get install -y conntrack
+
+# Install crictl
+VERSION="v1.24.2"
+wget https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/crictl-$VERSION-linux-amd64.tar.gz
+sudo tar zxvf crictl-$VERSION-linux-amd64.tar.gz -C /usr/local/bin
+rm -f crictl-$VERSION-linux-amd64.tar.gz
+
+# Install Minikube
+curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
+chmod +x minikube
+sudo mv minikube /usr/local/bin/
+minikube version
+
+# Install containernetworking-plugins
+CNI_PLUGIN_VERSION="v1.6.0"
+CNI_PLUGIN_TAR="cni-plugins-linux-amd64-$CNI_PLUGIN_VERSION.tgz"
+CNI_PLUGIN_INSTALL_DIR="/opt/cni/bin"
+curl -LO "https://github.com/containernetworking/plugins/releases/download/$CNI_PLUGIN_VERSION/$CNI_PLUGIN_TAR"
+sudo mkdir -p "$CNI_PLUGIN_INSTALL_DIR"
+sudo tar -xf "$CNI_PLUGIN_TAR" -C "$CNI_PLUGIN_INSTALL_DIR"
+rm "$CNI_PLUGIN_TAR"
+
+# Start Minikube and enable addons
+minikube start --driver=none
+kubectl get node
+minikube addons enable ingress
+minikube addons enable ingress-dns
+
+# Install Helm
+curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
+chmod 700 get_helm.sh
+./get_helm.sh
+helm version
+
+# Configure Ingress external IP if needed
+kubectl edit svc -n ingress-nginx
+
 ## Recommendations
 
 Use tools like the Minikube dashboard (or [Open Lens](https://k8slens.dev/)) to visualize your cluster and deployed components.

--- a/docs/user/setup/README.md
+++ b/docs/user/setup/README.md
@@ -198,7 +198,7 @@ After starting Minikube or Docker Desktop Kubernetes, verify the cluster setup:
 
 ### 3.1 Windows with WSL
 
-Follow these steps when running Ubuntu 22.04 LTS in WSL:
+Follow these steps when running Ubuntu in WSL:
 
 ```bash
 # Install kubectl
@@ -263,8 +263,19 @@ chmod 700 get_helm.sh
 ./get_helm.sh
 helm version
 
-# Configure Ingress external IP if needed
+# Configure Ingress external IP to point to minikube IP
 kubectl edit svc -n ingress-nginx
+
+Example configuration:
+
+```yaml
+spec:
+  clusterIP: 10.101.189.214
+  clusterIPs:
+  - 10.101.189.214
+  externalIPs:
+  - <MINIKUBE_IP>
+```
 
 ## Recommendations
 

--- a/docs/user/setup/README.md
+++ b/docs/user/setup/README.md
@@ -25,6 +25,7 @@ The above specifications are the minimum requirements for a local development se
   - [using Minikube with Docker Desktop](#option-1-docker-desktop-available)
   - [using K3s with lima](#option-2-no-docker-desktop-available)
 - [Windows](#3-windows)
+  - [Windows with Ubuntu WSL](#31-windows-with-ubuntu-wsl)
 
 ### 1. Linux
 
@@ -180,6 +181,96 @@ Alternatively, you can use the native Kubernetes cluster provided by Docker Desk
 
 > :warning: The rest of the tutorial assumes a minikube cluster, however.
 
+### 3.1. Windows with Ubuntu WSL
+
+Follow these steps when running Ubuntu in WSL (tested on Ubuntu 22.04/24.04):
+
+
+- Install kubectl
+```bash
+curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+chmod +x ./kubectl
+sudo mv ./kubectl /usr/local/bin/kubectl
+kubectl version
+```
+- Install Docker
+
+```bash
+sudo apt-get install -y ca-certificates curl gnupg lsb-release
+sudo mkdir -p /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+  $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt-get update
+sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
+sudo systemctl status docker
+sudo groupadd docker
+sudo usermod -aG docker $USER && newgrp docker
+sudo systemctl enable docker
+```
+
+- Install cri-dockerd
+```bash
+wget https://github.com/Mirantis/cri-dockerd/releases/download/v0.3.15/cri-dockerd_0.3.15.3-0.ubuntu-jammy_amd64.deb
+sudo dpkg -i cri-dockerd_0.3.15.3-0.ubuntu-jammy_amd64.deb
+```
+- Install conntrack
+```bash
+sudo apt-get install -y conntrack
+```
+- Install crictl
+```bash
+VERSION="v1.24.2"
+wget https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/crictl-$VERSION-linux-amd64.tar.gz
+sudo tar zxvf crictl-$VERSION-linux-amd64.tar.gz -C /usr/local/bin
+rm -f crictl-$VERSION-linux-amd64.tar.gz
+```
+- Install Minikube
+```bash
+curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
+chmod +x minikube
+sudo mv minikube /usr/local/bin/
+minikube version
+```
+- Install containernetworking-plugins
+```bash
+CNI_PLUGIN_VERSION="v1.6.0"
+CNI_PLUGIN_TAR="cni-plugins-linux-amd64-$CNI_PLUGIN_VERSION.tgz"
+CNI_PLUGIN_INSTALL_DIR="/opt/cni/bin"
+curl -LO "https://github.com/containernetworking/plugins/releases/download/$CNI_PLUGIN_VERSION/$CNI_PLUGIN_TAR"
+sudo mkdir -p "$CNI_PLUGIN_INSTALL_DIR"
+sudo tar -xf "$CNI_PLUGIN_TAR" -C "$CNI_PLUGIN_INSTALL_DIR"
+rm "$CNI_PLUGIN_TAR"
+```
+- Start Minikube and enable addons
+```bash
+minikube start --driver=none
+kubectl get node
+minikube addons enable ingress
+minikube addons enable ingress-dns
+```
+- Install Helm
+```bash
+curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
+chmod 700 get_helm.sh
+./get_helm.sh
+helm version
+```
+- Configure Ingress - set external IP to the minikube IP (add externalIPs below clusterIPs, as listed in the example)
+```bash
+kubectl edit svc ingress-nginx-controller -n ingress-nginx
+```
+Example configuration:
+
+```yaml
+spec:
+  clusterIP: 10.101.189.214
+  clusterIPs:
+  - 10.101.189.214
+  externalIPs:
+  - <MINIKUBE_IP>
+```
+
 ## Verifying the Cluster
 
 After starting Minikube or Docker Desktop Kubernetes, verify the cluster setup:
@@ -195,88 +286,6 @@ After starting Minikube or Docker Desktop Kubernetes, verify the cluster setup:
   ```bash
   minikube dashboard
   ```
-
-### 3.1 Windows with WSL
-
-Follow these steps when running Ubuntu in WSL:
-
-```bash
-# Install kubectl
-curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
-chmod +x ./kubectl
-sudo mv ./kubectl /usr/local/bin/kubectl
-kubectl version
-
-# Install Docker
-sudo apt-get install -y ca-certificates curl gnupg lsb-release
-sudo mkdir -p /etc/apt/keyrings
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-
-echo \
-  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
-  $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-
-sudo apt-get update
-sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
-sudo systemctl status docker
-sudo groupadd docker
-sudo usermod -aG docker $USER && newgrp docker
-sudo systemctl enable docker
-
-# Install cri-dockerd
-wget https://github.com/Mirantis/cri-dockerd/releases/download/v0.3.15/cri-dockerd_0.3.15.3-0.ubuntu-jammy_amd64.deb
-sudo dpkg -i cri-dockerd_0.3.15.3-0.ubuntu-jammy_amd64.deb
-
-# Install conntrack
-sudo apt-get install -y conntrack
-
-# Install crictl
-VERSION="v1.24.2"
-wget https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/crictl-$VERSION-linux-amd64.tar.gz
-sudo tar zxvf crictl-$VERSION-linux-amd64.tar.gz -C /usr/local/bin
-rm -f crictl-$VERSION-linux-amd64.tar.gz
-
-# Install Minikube
-curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
-chmod +x minikube
-sudo mv minikube /usr/local/bin/
-minikube version
-
-# Install containernetworking-plugins
-CNI_PLUGIN_VERSION="v1.6.0"
-CNI_PLUGIN_TAR="cni-plugins-linux-amd64-$CNI_PLUGIN_VERSION.tgz"
-CNI_PLUGIN_INSTALL_DIR="/opt/cni/bin"
-curl -LO "https://github.com/containernetworking/plugins/releases/download/$CNI_PLUGIN_VERSION/$CNI_PLUGIN_TAR"
-sudo mkdir -p "$CNI_PLUGIN_INSTALL_DIR"
-sudo tar -xf "$CNI_PLUGIN_TAR" -C "$CNI_PLUGIN_INSTALL_DIR"
-rm "$CNI_PLUGIN_TAR"
-
-# Start Minikube and enable addons
-minikube start --driver=none
-kubectl get node
-minikube addons enable ingress
-minikube addons enable ingress-dns
-
-# Install Helm
-curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
-chmod 700 get_helm.sh
-./get_helm.sh
-helm version
-
-# Configure Ingress external IP to point to minikube IP
-kubectl edit svc -n ingress-nginx
-
-Example configuration:
-
-```yaml
-spec:
-  clusterIP: 10.101.189.214
-  clusterIPs:
-  - 10.101.189.214
-  externalIPs:
-  - <MINIKUBE_IP>
-```
-
 ## Recommendations
 
 Use tools like the Minikube dashboard (or [Open Lens](https://k8slens.dev/)) to visualize your cluster and deployed components.


### PR DESCRIPTION

## Description
Update Cluster Setup documentation with step 3.1. Windows with Ubuntu WSL 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
