### PR TITLE
docs: troubleshooting section for dns related issues

### DIFF
--- a/docs/user/network/README.md
+++ b/docs/user/network/README.md
@@ -334,27 +334,27 @@ In certain circumstances, this mechanism can lead to issues such as domain name 
 
 - umbrella-dataprovider-post-install-testdata-...  pod fails
 - It is not possible to query DSP catalog because of the HTTP 500 ERROR. 
-- When looking into umbrella-dataconsumer-1-edc-controlplane logs there are this kind of error messages:  
+- When looking into umbrella-dataconsumer-1-edc-controlplane logs, there are this kind of error messages:
 
    ```text
    HTTP client exception caught for request [POST, http://ssi-dim-wallet-stub.tx.test/oauth/token]
    org.eclipse.edc.http.spi.EdcHttpClientException: ssi-dim-wallet-stub.tx.test: Try again
    ```
 
-- There are some timeout errors related to domain names resolution in CoreDns log
+- There are some timeout errors related to domain names resolution in CoreDns log:
 
    ```text
    [ERROR] plugin/errors: 2 ssi-dim-wallet-stub.tx.test.some-domain.com. A: read udp 10.244.1.154:36890->8.8.8.8:53: i/o timeout
    [ERROR] plugin/errors: 2 ssi-dim-wallet-stub.tx.test.some-domain.com. AAAA: read udp 10.244.1.154:35576->8.8.8.8:53: i/o timeout
    ```
 
-- When trying to ping any domain from inside any pod in the cluster, domain name resolution fails or takes long time.  Adding a dot (for example `google.com.`)  at the end of the domain fixes the issue.  
+- When trying to ping any domain from inside any pod in the cluster, domain name resolution fails or gets timeout. Adding a dot (for example `google.com.`) at the end of the domain fixes the issue.
 
 **Solution**
 
 Prevent pods from inheriting `/etc/resolv.conf` search field values from the Minikube node.
 
-1. Log in to Minikube node, using `ssh`. 
+1. Log into Minikube node, using `ssh`.
 
    ```bash
    minikube ssh
@@ -372,14 +372,14 @@ Prevent pods from inheriting `/etc/resolv.conf` search field values from the Min
    cp /etc/resolv.conf  /etc/umbrella.resolv.conf
    ```
 
-3. Using `vim` or `nano` or any other text editor, open the `/etc/umbrella.resolv.conf` file and **comment out the "search"** line. Save the file. Exit Minikube console.
+3. Using `vim`, `nano` or any other text editor, open the `/etc/umbrella.resolv.conf` file and **comment out the "search"** line. Save the file. Exit Minikube console.
 
    ```shell
    vim /etc/umbrella.resolv.conf
    exit
    ```
 
-4. Stop the Minikube and start it again appending the following flag to minikube startup command:
+4. Stop the Minikube and start it again appending the following flag to Minikube startup command:
    
    ```text
    --extra-config=kubelet.resolv-conf="/etc/umbrella.resolv.conf"

--- a/docs/user/network/README.md
+++ b/docs/user/network/README.md
@@ -314,6 +314,78 @@ Once the DNS resolution or hosts file is configured:
 
 1. Ensure ingress is working by accessing a service endpoint, such as <http://portal.tx.test>
 
+---
+
+## Troubleshooting
+
+### DNS resolution fails due to resolution timeouts
+
+**Problem background**
+
+Minikube node DNS settings are inherited from the configuration specified in the /etc/resolv.conf file on the host where Minikube is running. This particularly applies to the search field in the resolv.conf file.
+The values defined in the search field are propagated to individual pods within the cluster. 
+
+The serach field contains a list of domain suffixes that are appended to queried domain names. 
+These modified domain names are then sequentially resolved by the DNS server.
+
+In certain circumstances, this mechanism can lead to issues such as domain name resolution timeouts.
+
+**Probem sysmptoms**
+
+- umbrella-dataprovider-post-install-testdata-...  pod fails
+- It is not possible to query DSP catalog because of the HTTP 500 ERROR. 
+- When looking into umbrella-dataconsumer-1-edc-controlplane logs there are this kind of error messeges:  
+```
+HTTP client exception caught for request [POST, http://ssi-dim-wallet-stub.tx.test/oauth/token]
+org.eclipse.edc.http.spi.EdcHttpClientException: ssi-dim-wallet-stub.tx.test: Try again
+```
+- There are some timeout errors related to domain names resolution in CoreDns log
+ ```text
+[ERROR] plugin/errors: 2 ssi-dim-wallet-stub.tx.test.domain.com. A: read udp 10.244.1.154:36890->8.8.8.8:53: i/o timeout
+[ERROR] plugin/errors: 2 ssi-dim-wallet-stub.tx.test.domain.com. AAAA: read udp 10.244.1.154:35576->8.8.8.8:53: i/o timeout
+```
+- When trying to ping any domains from the inside of any clustes' pods, domain name resolution fails or takes long time.  Adding a dot (for example google.com.)  at the end of the domain fixes the issue.  
+
+**Solution**
+
+Prevent pods from inheriting /etc/resolv.conf search filed values form the Minikube node.
+
+1. Log in to Minikube node, using ssh. 
+
+   ```bash
+   minikube ssh
+   ```
+
+   In the Minikube node, install any text editor, for example vim:
+
+   ```bash
+   sudo apt update && apt install vim
+   ```
+ 
+2. While still in the Minikube node console, duplicate existing /etc/resolv.conf file, for example:
+
+   ```shell
+   cp /etc/resolv.conf  /etc/umbrella.resolv.conf
+   ```
+
+3. Using vim or nano or any other text editor, open the /etc/umbrella.resolv.conf file and comment out the "search" line. Save the file. Exit Minikube console.
+
+   ```shell
+   vim /etc/umbrella.resolv.conf
+   exit
+   ```
+
+4. Stop the Minikube and start it again appending the fallowing flag to minikube startup command:
+   
+   ```text
+   --extra-config=kubelet.resolv-conf="/etc/umbrella.resolv.conf"
+   ```
+   So the final Minikube startup command will look like this:
+   ```shell
+   minikube start --cpus=4 --memory=6gb --extra-config=kubelet.resolv-conf="/etc/umbrella.resolv.conf"
+   ```
+
+
 ## NOTICE
 
 This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).


### PR DESCRIPTION
## Description
This PR adds a Troubleshooting section to the Tractus-X Umbrella Configuration and Networking documentation. It includes a description of and a solution to an issue related to domain name resolution. The problem may occur even when all existing instructions in the documentation are followed correctly.

The issue may arise due to specific DNS settings in the company's environment. Including the solution in the documentation could help save time for other users facing a similar problem.

Closes #300

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
