### PR TITLE
feat: update ssi-credential-issuer to v1.4.0

### DIFF
--- a/charts/umbrella/Chart.yaml
+++ b/charts/umbrella/Chart.yaml
@@ -66,7 +66,7 @@ dependencies:
   - name: ssi-credential-issuer
     condition: ssi-credential-issuer.enabled
     repository: https://eclipse-tractusx.github.io/charts/dev
-    version: 1.3.0
+    version: 1.4.0
   # semantic-hub
   - condition: semantic-hub.enabled
     name: semantic-hub

--- a/docs/user/installation/README.md
+++ b/docs/user/installation/README.md
@@ -13,7 +13,7 @@ The currently available components are the following:
 - [discoveryfinder](https://github.com/eclipse-tractusx/sldt-discovery-finder/tree/discoveryfinder-0.5.1)
 - [sdfactory](https://github.com/eclipse-tractusx/sd-factory/tree/sdfactory-2.1.23)
 - [semantic-hub](https://github.com/eclipse-tractusx/sldt-semantic-hub/tree/semantic-hub-0.5.0)
-- [ssi credential issuer](https://github.com/eclipse-tractusx/ssi-credential-issuer/tree/v1.3.0)
+- [ssi credential issuer](https://github.com/eclipse-tractusx/ssi-credential-issuer/tree/v1.4.0)
 - [tx-data-provider](https://github.com/eclipse-tractusx/tractus-x-umbrella/tree/main/charts/tx-data-provider)
   - [dataspace-connector-bundle](../../../charts/dataspace-connector-bundle)
     - [tractusx-edc](https://github.com/eclipse-tractusx/tractusx-edc/tree/0.9.0)


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

Upgraded SSI Credential Issuer component for R25.06

ssi-credential-issuer v1.4.0

Closes https://github.com/eclipse-tractusx/tractus-x-umbrella/issues/288

Pre-review

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
