### PR TITLE
chore(umbrella): Remove unused keycloak.enabled flag from ssi-dim-wallet-stub

### DIFF
--- a/charts/umbrella/Chart.yaml
+++ b/charts/umbrella/Chart.yaml
@@ -28,7 +28,7 @@ sources:
   - https://github.com/eclipse-tractusx/tractus-x-umbrella
 
 type: application
-version: 3.4.0
+version: 3.4.1
 
 # when adding or updating versions of dependencies, also update list under /docs/user/installation/README.md
 dependencies:

--- a/charts/umbrella/values.yaml
+++ b/charts/umbrella/values.yaml
@@ -1492,8 +1492,6 @@ identity-and-trust-bundle:
       service:
         type: ClusterIP
         port: 8080
-    keycloak:
-      enabled: false
 
 smtp4dev:
   enabled: false


### PR DESCRIPTION
The  setting under  is never used in this chart and only confuses new adopters who see Keycloak creds configured elsewhere. Drop the two lines to clean up defaults.


## Description

### Please describe your PR

This PR removes the two lines:
```yaml
  keycloak:
    enabled: false
```
from the `ssi-dim-wallet-stub` section of the umbrella chart’s `values.yaml`. These fields aren't needed for this chart (we never spin up a testing Keycloak instance for that stub).  It rather confuses new users who see Keycloak credentials configured under `ssi-dim-wallet-stub.keycloak` but assume they must also toggle `enabled: true` here. See:

```yaml
ssi-dim-wallet-stub:
    wallet:
      replicaCount: 1
      [...]
      keycloak:
        realm: "CX-Central"
        authServerUrl: "http://centralidp.tx.test/auth"
      service:
        type: ClusterIP
        port: 8080
    keycloak:
      enabled: false
```

### What does this PR introduce? 

More clarity during the configuration of the `ssi-dim-wallet-stub.keycloak` using the `values.yaml`

### Does it fix a bug? 

No.

### Does it add a new feature?

No.

### Is it enhancing documentation?

Yes.

### Related Issues

The issue was raised and discussed on the `Umbrella Helm chart sync` meeting on 7th July 2025.
With the removal, there is also no additional documentation for that config needed, since from now on, one will only find it in the original chart. In regards to the documentation, see the PR https://github.com/eclipse-tractusx/ssi-dim-wallet-stub/pull/72 for describing the config more detailed. 


## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
