### PR TITLE
feat: Add possibility of overriding image in testdata and vault setup

### DIFF
--- a/charts/tx-data-provider/Chart.yaml
+++ b/charts/tx-data-provider/Chart.yaml
@@ -23,7 +23,7 @@ name: tx-data-provider
 description: A Helm chart for Kubernetes
 
 type: application
-version: 0.3.1
+version: 0.3.2
 appVersion: 0.0.1
 
 dependencies:

--- a/charts/tx-data-provider/templates/post-install-job-upload-testdata.yaml
+++ b/charts/tx-data-provider/templates/post-install-job-upload-testdata.yaml
@@ -54,7 +54,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: post-install-job
-          image: "python:3.11"
+          image: {{ .Values.testData.image | quote }}
           imagePullPolicy: "IfNotPresent"
           command:
             - "/bin/sh"

--- a/charts/tx-data-provider/templates/post-install-vault-setup.yaml
+++ b/charts/tx-data-provider/templates/post-install-vault-setup.yaml
@@ -48,7 +48,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: post-install-job
-          image: "alpine:3.19"
+          image: {{ .Values.vaultSetup.image | quote }}
           imagePullPolicy: "IfNotPresent"
           command:
             - "/bin/sh"

--- a/charts/tx-data-provider/values.yaml
+++ b/charts/tx-data-provider/values.yaml
@@ -26,12 +26,16 @@ configuration:
 nameOverride: ""
 fullnameOverride: ""
 seedTestdata: false  # Toggle seeding of testdata. Can be enabled when the edc should be seeded with testdata on startup.
+testData:
+  image: python:3.11
 testdataConfigMap: ""  # Provide a custom configmap for post-install-job-upload-testdata.yaml.
 backendUrl: ""  # Override the backend service url
 registryUrl: ""  # Override the digital twin registry url
 controlplanePublicUrl: ""  # Override the edc controlplane protocol url
 controlplaneManagementUrl: ""  # Override the edc controlplane management url
 dataplaneUrl: ""  # Override the edc dataplane public url
+vaultSetup:
+  image: alpine:3.19
 secrets:
   edc-wallet-secret: changeme
 

--- a/charts/umbrella/Chart.yaml
+++ b/charts/umbrella/Chart.yaml
@@ -28,7 +28,7 @@ sources:
   - https://github.com/eclipse-tractusx/tractus-x-umbrella
 
 type: application
-version: 3.6.2
+version: 3.6.3
 
 # when adding or updating versions of dependencies, also update list under /docs/user/installation/README.md
 dependencies:
@@ -80,18 +80,18 @@ dependencies:
     # TX Data Consumer 1
   - name: tx-data-provider
     alias: dataconsumerOne
-    version: 0.3.1
+    version: 0.3.2
     repository: file://../tx-data-provider
     condition: dataconsumerOne.enabled
     # TX Data Providers
   - name: tx-data-provider
-    version: 0.3.1
+    version: 0.3.2
     repository: file://../tx-data-provider
     condition: tx-data-provider.enabled
     # TX Data Consumer 2
   - name: tx-data-provider
     alias: dataconsumerTwo
-    version: 0.3.1
+    version: 0.3.2
     repository: file://../tx-data-provider
     condition: dataconsumerTwo.enabled
     # pgadmin4 as helper tool for easy database access


### PR DESCRIPTION
## Description

This PR allows for overriding the image tag in the testdata and vault setup hooks.

We had some issues with image fetching directly from Docker Hub being blocked, possibly due to request limiting. With this change, we will be able to fetch the image through ACR which acts as a proxy, with caching rules to prevent too many requests to Docker Hub.

## Pre-review checks

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
