### PR TITLE
chore: Update PostgreSQL image repository to bitnamilegacy for wallet and credential issuer configurations

### DIFF
--- a/charts/identity-and-trust-bundle/values.yaml
+++ b/charts/identity-and-trust-bundle/values.yaml
@@ -148,8 +148,11 @@ ssi-dim-wallet-stub:
   postgresql:
     fullnameOverride: wallet-postgres
     enabled: true
+    ## TEMPORALY UNTIL NEW SSI-DIM-WALLET-STUB UPDATE
     image:
-      tag: "15-debian-11"
+      repository: bitnamilegacy/postgresql
+      tag: 15-debian-11
+    ## UNTIL HERE
     configmap:
       name: wallet-postgres-configmap
     auth:

--- a/charts/umbrella/values.yaml
+++ b/charts/umbrella/values.yaml
@@ -585,6 +585,12 @@ sharedidp:
   enabled: false
   keycloak:
     nameOverride: "sharedidp"
+    # TEMPORARY UNTIL PORTAL-IAM VERSION IS UPDATED
+    image:
+      registry: docker.io
+      repository: bitnamilegacy/keycloak
+      tag: 25.0.6-debian-12-r0
+    ## UNTIL HERE
     auth:
       adminPassword: "adminconsolepwsharedidp"
     postgresql:
@@ -857,6 +863,11 @@ ssi-credential-issuer:
     enabled: true
     nameOverride: issuer-postgresql
     architecture: standalone
+    ## TEMPORALY UNTIL NEW SSI-CREDENTIAL-ISSUER UPDATE
+    image:
+      repository: bitnamilegacy/postgresql
+      tag: 15-debian-11
+    ## UNTIL HERE
     primary:
       persistence:
         enabled: false
@@ -899,6 +910,11 @@ bpdm:
     # We use the default name for BPDM postgres
     fullnameOverride: &bpdmPostgresName "bpdm-postgres"
     nameOverride:
+    ## TEMPORALY UNTIL NEW BPDM UPDATE
+    image:
+      repository: bitnamilegacy/postgresql
+      tag: 15-debian-11
+    ## UNTIL HERE
     auth:
       # BPDM can't handle random initial passwords at the moment
       # so need to set a fixed one here and use it in the app configs later


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
This pull request introduces temporary changes to several Helm chart value files, updating the container image repositories for PostgreSQL and Keycloak to use legacy Bitnami images. These updates are intended to maintain compatibility until newer versions of the affected services are released.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
