### PR TITLE
chore: Upgraded bdrs to 25-09

### DIFF
--- a/charts/umbrella/Chart.yaml
+++ b/charts/umbrella/Chart.yaml
@@ -28,7 +28,7 @@ sources:
   - https://github.com/eclipse-tractusx/tractus-x-umbrella
 
 type: application
-version: 3.10.0
+version: 3.11.0
 
 # when adding or updating versions of dependencies, also update list under /docs/user/installation/README.md
 dependencies:
@@ -102,7 +102,7 @@ dependencies:
     # bdrs
   - name: bdrs-server-memory
     repository: https://eclipse-tractusx.github.io/charts/dev
-    version: 0.5.4
+    version: 0.5.7
     condition: bdrs-server-memory.enabled
   - name: identity-and-trust-bundle
     repository: file://../identity-and-trust-bundle

--- a/docs/user/installation/README.md
+++ b/docs/user/installation/README.md
@@ -30,7 +30,7 @@ The currently available components are the following:
   - [dataspace-connector-bundle](../../../charts/dataspace-connector-bundle)
     - [tractusx-edc](https://github.com/eclipse-tractusx/tractusx-edc/tree/0.10.0)
     - [vault](https://github.com/hashicorp/vault-helm/tree/v0.20.0)
-- [bdrs](https://github.com/eclipse-tractusx/bpn-did-resolution-service/tree/0.5.2) (**in memory** - no persistence possible)
+- [bdrs](https://github.com/eclipse-tractusx/bpn-did-resolution-service/tree/0.5.7) (**in memory** - no persistence possible)
 - [bpdm](https://github.com/eclipse-tractusx/bpdm/tree/release/7.0.x)
 - [identity-and-trust-bundle](../../../charts/identity-and-trust-bundle)
   - [ssi-dim-wallet-stub](https://github.com/eclipse-tractusx/ssi-dim-wallet-stub/tree/ssi-dim-wallet-stub-memory-0.1.11)


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->


- Updated bdrs-server-memory sub chart version to `0.5.7` to umbrella dependencies
- Updated umbrella chart version to `3.11.0`

## Linked Issue(s):
https://github.com/eclipse-tractusx/tractus-x-umbrella/issues/333

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
