### PR TITLE
fix: fix indentation of service and resources in identity-and-trust-bundle

### DIFF
--- a/charts/umbrella/Chart.yaml
+++ b/charts/umbrella/Chart.yaml
@@ -28,7 +28,7 @@ sources:
   - https://github.com/eclipse-tractusx/tractus-x-umbrella
 
 type: application
-version: 3.14.5
+version: 3.14.6
 
 # when adding or updating versions of dependencies, also update list under /docs/user/linux/installation/README.md
 dependencies:

--- a/charts/umbrella/values.yaml
+++ b/charts/umbrella/values.yaml
@@ -1543,20 +1543,20 @@ identity-and-trust-bundle:
       postgresql:
         username: "postgres"
         password: "postgrespassword"
-    service:
-      type: ClusterIP
-      port: 8080
-    resources:
-      requests:
-        # -- CPU resource requests
-        cpu: 500m
-        # -- Memory resource requests
-        memory: 1Gi
-      limits:
-        # -- CPU resource limits
-        cpu: 1
-        # -- Memory resource limits
-        memory: 2Gi
+      service:
+        type: ClusterIP
+        port: 8080
+      resources:
+        requests:
+          # -- CPU resource requests
+          cpu: 500m
+          # -- Memory resource requests
+          memory: 1Gi
+        limits:
+          # -- CPU resource limits
+          cpu: 1
+          # -- Memory resource limits
+          memory: 2Gi
   postgresql:
     fullnameOverride: wallet-postgres
     enabled: true


### PR DESCRIPTION

## Description


Fixes incorrect YAML indentation in `charts/umbrella/values.yaml`.

The `service` and `resources` blocks under `identity-and-trust-bundle` were mistakenly nested under `postgresql`, causing them to be ignored by Helm. This PR moves them to the correct level and bumps the chart version in `Chart.yaml`.



## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
