### PR TITLE
fix: curl commands with latest EDC version

### DIFF
--- a/docs/user/common/guides/data-exchange/consume-data.md
+++ b/docs/user/common/guides/data-exchange/consume-data.md
@@ -74,7 +74,13 @@ curl -L -X POST 'http://dataconsumer-1-controlplane.tx.test/management/v3/catalo
       "limit": 50,
       "sortOrder": "DESC",
       "sortField": "fieldName",
-      "filterExpression": []
+      "filterExpression": [
+        {
+          "operandLeft": "https://w3id.org/edc/v0.0.1/ns/id",
+          "operator": "=",
+          "operandRight": "{{ASSET_ID}}"
+        }
+      ]
     }
   }' | jq
 ```
@@ -130,7 +136,7 @@ curl -L -X POST 'http://dataconsumer-1-controlplane.tx.test/management/v3/edrs' 
       }
     ],
     "@type": "ContractRequest",
-    "counterPartyAddress": "http://dataprovider-controlplane.tx.test/api/v1/dsp",
+    "counterPartyAddress": "http://dataprovider-controlplane.tx.test/api/v1/dsp/2025-1",
     "protocol": "dataspace-protocol-http:2025-1",
     "policy": {
       "@id": "{{OFFER_ID}}",


### PR DESCRIPTION
## Description
Fix curl command documentation to be up to date with the last connector updates.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
