### PR TITLE
feat: add deleteData method to SimpleDataServiceController

### DIFF
--- a/simple-data-backend/src/main/java/org/eclipse/tractusx/simpledataservice/SimpleDataServiceController.java
+++ b/simple-data-backend/src/main/java/org/eclipse/tractusx/simpledataservice/SimpleDataServiceController.java
@@ -1,6 +1,7 @@
 /********************************************************************************
  * Copyright (c) 2022,2024 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
- * Copyright (c) 2021,2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021,2026 Contributors to the Eclipse Foundation
+ * Copyright (c) 2026 Catena-X Automotive Network e.V.
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -23,6 +24,7 @@ import java.util.HashMap;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -48,6 +50,16 @@ public class SimpleDataServiceController {
         if (data.containsKey(id)) {
             log.info("Returning data for id '{}'", id);
             return data.get(id);
+        } else {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "No data found with id '%s'".formatted(id));
+        }
+    }
+
+    @DeleteMapping("/{id}")
+    public void deleteData(@PathVariable final String id) {
+        if (data.containsKey(id)) {
+            log.info("Deleting data for id '{}'", id);
+            data.remove(id);
         } else {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "No data found with id '%s'".formatted(id));
         }

--- a/simple-data-backend/src/test/java/org/eclipse/tractusx/simpledataservice/SimpleDataServiceControllerTest.java
+++ b/simple-data-backend/src/test/java/org/eclipse/tractusx/simpledataservice/SimpleDataServiceControllerTest.java
@@ -25,7 +25,58 @@ class SimpleDataServiceControllerTest {
         final Object actualResponse = simpleDataServiceController.getData("test");
         assertThat(actualResponse).isEqualTo(payload);
     }
+    
+    @Test
+    void shouldOverwriteData() {
+        // Arrange
+        final SimpleDataServiceController simpleDataServiceController = new SimpleDataServiceController();
+        final String initialPayload = """
+                {
+                    "test": "initial"
+                }
+                """;
+        final String updatedPayload = """
+                {
+                    "test": "updated"
+                }
+                """;
 
+        // Act
+        simpleDataServiceController.addData("test", initialPayload);
+        simpleDataServiceController.addData("test", updatedPayload);
+
+        // Assert
+        final Object actualResponse = simpleDataServiceController.getData("test");
+        assertThat(actualResponse).isEqualTo(updatedPayload);
+    }
+
+    @Test
+    void shouldDeleteData() {
+        // Arrange
+        final SimpleDataServiceController simpleDataServiceController = new SimpleDataServiceController();
+        final String payload = """
+                {
+                    "test": "data"
+                }
+                """;
+        simpleDataServiceController.addData("test", payload);
+
+        // Act
+        simpleDataServiceController.deleteData("test");
+
+        // Assert
+        assertThatExceptionOfType(ResponseStatusException.class).isThrownBy(() -> simpleDataServiceController.getData("test"));
+    }
+
+    @Test
+    void shouldThrowNotFoundExceptionOnDelete() {
+        // Arrange
+        final SimpleDataServiceController simpleDataServiceController = new SimpleDataServiceController();
+
+        // Act & Assert
+        assertThatExceptionOfType(ResponseStatusException.class).isThrownBy(() -> simpleDataServiceController.deleteData("test"));
+    }
+    
     @Test
     void shouldThrowNotFoundException() {
         // Arrange


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->
## Description

This pull request introduces a new endpoint to the `SimpleDataServiceController` for deleting data entries by ID, and updates copyright notices.

**API Enhancements:**

* Added a `DELETE /{id}` endpoint to `SimpleDataServiceController` that removes data entries by ID and returns a 404 error if the entry does not exist.
* Imported `DeleteMapping` annotation to support the new delete endpoint.
* Added unit tests to test delete, and overwrite 


**Legal/Documentation Updates:**

* Updated copyright years for contributors and added Catena-X Automotive Network e.V. to the copyright notice.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
