### PR TITLE
fix: Helm version 8 causes conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The Umbrella Chart is intended for:
 
 - Ensure your cluster meets the updated system requirements:
   - Kubernetes version `>1.24.x`
-  - Helm version `3.8+`
+  - Helm version `3.12+`
 
 For detailed setup instructions, refer to the [Setup Guide](/docs/README.md#setup-network--installation).
 


### PR DESCRIPTION
Hi!
I apologize for the delay in issuing this fix. As I observed during the hackathon, some charts were giving me trouble and wouldn't start properly, causing problems. 
After investigating the issue, I realized it was related to the Helm version. The documentation stated that version 3.8 and later were sufficient, but those versions still cause problems in some cases. 
After researching and testing, I found that the minimum version where these conflicts seem to disappear is 3.12, hence the change I'm suggesting.
Thanks for the great work you're doing, team!