### PR TITLE
chore(migrate-action-version): migrate checkout version

### DIFF
--- a/.github/workflows/build-sdb-image.yaml
+++ b/.github/workflows/build-sdb-image.yaml
@@ -26,7 +26,6 @@ on:
       - main
     paths:
       - 'simple-data-backend/**'
-    # trigger events for SemVer like tags
     tags:
       - '*.*.*'
       - '*.*.*-*'
@@ -50,25 +49,20 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      # Needed to create multi-platform image
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # Needed to create multi-platform image
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
-      # Create SemVer or ref tags dependent of trigger event
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: |
             ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
-          # Automatically prepare image tags; See action docs for more examples.
-          # semver patter will generate tags like these for example :1 :1.2 :1.2.3
           tags: |
             type=ref,event=branch
             type=ref,event=pr
@@ -80,7 +74,6 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
-          # Use existing DockerHub credentials present as secrets
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
@@ -88,20 +81,15 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: ./simple-data-backend/
-          # Needed to create multi-platform image
           platforms: ${{ env.TARGET_PLATFORMS }}
-          # Build image for verification purposes on every trigger event. Only push if event is not a PR
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
-      # https://github.com/peter-evans/dockerhub-description
-      # Important step to push image description to DockerHub
       - name: Update Docker Hub description
         if: github.event_name != 'pull_request'
         uses: peter-evans/dockerhub-description@v4
         with:
-          # readme-filepath defaults to toplevel README.md, Only necessary if you have a dedicated file with your 'Notice for docker images'
           readme-filepath: ./simple-data-backend/DOCKER_NOTICE.md
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -27,8 +27,6 @@ on:
       - main
 jobs:
   release:
-    # depending on default permission settings for your org (contents being read-only or read-write for workloads), you will have to add permissions
-    # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
     permissions:
       contents: write
     runs-on: ubuntu-latest
@@ -36,7 +34,7 @@ jobs:
     steps:
       # fetch-depth: 0 is required to determine differences in chart(s)
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/eclipse-dash.yml
+++ b/.github/workflows/eclipse-dash.yml
@@ -38,7 +38,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4

--- a/.github/workflows/helm-checks.yaml
+++ b/.github/workflows/helm-checks.yaml
@@ -25,23 +25,13 @@ on:
       - 'charts/**'
       - '!**/README.md'
       - '.github/workflows/helm-checks.yaml'
-    # branches:
-    #   - main
   workflow_dispatch:
     inputs:
       node_image:
         description: 'kindest/node image for k8s kind cluster'
-        # k8s version from 3.1 release as default
-        default: 'kindest/node:v1.27.3'
+        default: 'kindest/node:v1.30.0'
         required: false
         type: string
-      ## Skip upgrade for now until a working chart is released
-      #upgrade_from:
-      #  description: 'chart version to upgrade from'
-      #  # chart version from 3.1 release as default
-      #  default: 'x.x.x'
-      #  required: false
-      #  type: string
       helm_version:
         description: 'helm version to test (default = latest)'
         default: 'latest'
@@ -55,7 +45,7 @@ jobs:
       changed: "${{ steps.list-changed.outputs.changed }}"
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
         fetch-depth: 0
 
@@ -85,7 +75,7 @@ jobs:
       id: list-changed
       run: |
         changed=$(ct list-changed --target-branch ${{ steps.set-target-branch.outputs.target-branch }})
-        if [[ -n "$changed" ]]; then
+        if [[  -n "$changed" ]]; then
           echo "changed=true" >> $GITHUB_OUTPUT
         fi
 
@@ -95,22 +85,19 @@ jobs:
     if: ${{ github.event_name != 'pull_request' || needs.list-changed.outputs.changed == 'true' }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
         fetch-depth: 0
 
     - name: Kubernetes KinD Cluster
       uses: container-tools/kind-action@0ad70e2299366b0e1552c7240f4e4567148f723e #v2.0.4
       with:
-        # upgrade version, default (v0.17.0) uses node image v1.21.1 and doesn't work with more recent node image versions
         version: v0.20.0
-        # default value for event_name != workflow_dispatch
-        node_image: ${{ github.event.inputs.node_image || 'kindest/node:v1.27.3' }}
+        node_image: ${{ github.event.inputs.node_image || 'kindest/node:v1.30.0' }}
 
     - name: Informational - describe node
       run: kubectl describe node
 
-      # Pull and build Jena Fuseki DB for semantic-hub
     - name: Pull Fuseki sources
       run: |
         curl https://repo1.maven.org/maven2/org/apache/jena/jena-fuseki-docker/5.0.0/jena-fuseki-docker-5.0.0.zip > ./jena-fuseki.zip
@@ -206,151 +193,70 @@ jobs:
           -f charts/values-test-data-exchange.yaml; then
           
           echo "--- Helm installation failed. Executing post-mortem diagnosis. ---"
-          
-          echo "--- Getting pods status in 'umbrella' namespace ---"
           kubectl get pods -n umbrella
-          
-          echo "--- Getting logs for all pods in 'umbrella' namespace ---"
           for pod in $(kubectl get pods -n umbrella -o=jsonpath='{.items[*].metadata.name}'); do
             echo "--- Logs for pod: $pod ---"
             kubectl logs $pod -n umbrella || true
-            echo "--------------------------------------------------------"
           done
-          
-          echo "--- Getting events in 'umbrella' namespace ---"
           kubectl get events -n umbrella --sort-by='.metadata.creationTimestamp'
-          
-          echo "--- Helm history for 'umbrella' ---"
           helm history umbrella --namespace umbrella
-          
           exit 1
         fi
-        
-        echo "--- Installation successful. Starting cleanup... ---"
         helm uninstall umbrella --namespace umbrella
 
     - name: Install chart for centralidp Keycloak (umbrella)
       run: |
-        if ! helm install centralidp charts/umbrella --namespace umbrella --create-namespace --debug --timeout 10m \
+        if ! helm install centralidp charts/umbrella --namespace umbrella --create-namespace --debug --timeout 20m \
           -f charts/values-test-iam-init-container-1.yaml --wait --wait-for-jobs; then
-          
-          echo "--- Helm installation for 'centralidp' failed. Executing diagnosis. ---"
           kubectl get pods -n umbrella
-          
           for pod in $(kubectl get pods -n umbrella -o=jsonpath='{.items[*].metadata.name}'); do
             echo "--- Logs for pod: $pod ---"
             kubectl logs $pod -n umbrella || true
-            echo "--------------------------------------------------------"
           done
-          
           kubectl get events -n umbrella --sort-by='.metadata.creationTimestamp'
           helm history centralidp --namespace umbrella
-          
           exit 1
         fi
-
-        echo "--- Installation successful. ---"
 
     - name: Install chart for sharedidp Keycloak (umbrella)
       run: |
         if ! helm install umbrella charts/umbrella -f charts/values-test-iam-init-container-2.yaml --namespace umbrella --create-namespace --debug --timeout 10m; then
-
-          echo "--- Helm installation for 'sharedidp' failed. Executing diagnosis. ---"
           kubectl get pods -n umbrella
-          
           for pod in $(kubectl get pods -n umbrella -o=jsonpath='{.items[*].metadata.name}'); do
             echo "--- Logs for pod: $pod ---"
             kubectl logs $pod -n umbrella || true
-            echo "--------------------------------------------------------"
           done
-          
           kubectl get events -n umbrella --sort-by='.metadata.creationTimestamp'
           helm history umbrella --namespace umbrella
-          
           exit 1
         fi
-        
-        echo "--- Installation successful. Starting cleanup... ---"
         helm uninstall umbrella --namespace umbrella
         helm uninstall centralidp --namespace umbrella
 
     - name: Install chart for shared services one (umbrella)
       run: |
         if ! helm install umbrella charts/umbrella -f charts/values-test-shared-services-1.yaml --namespace umbrella --create-namespace --debug --timeout 10m; then
-
-          echo "--- Helm installation for 'shared services one' failed. Executing diagnosis. ---"
           kubectl get pods -n umbrella
-          
           for pod in $(kubectl get pods -n umbrella -o=jsonpath='{.items[*].metadata.name}'); do
             echo "--- Logs for pod: $pod ---"
             kubectl logs $pod -n umbrella || true
-            echo "--------------------------------------------------------"
           done
-          
           kubectl get events -n umbrella --sort-by='.metadata.creationTimestamp'
           helm history umbrella --namespace umbrella
-          
           exit 1
         fi
-        
-        echo "--- Installation successful. Starting cleanup... ---"
         helm uninstall umbrella --namespace umbrella
 
     - name: Install chart for shared services two (umbrella)
       run: |
         if ! helm install umbrella charts/umbrella -f charts/values-test-shared-services-2.yaml --namespace umbrella --create-namespace --debug --timeout 10m  --set semantic-hub.graphdb.image=kind-registry:5000/jena-fuseki-docker:5.0.0; then
-      
-          echo "--- Helm installation for 'shared services two' failed. Executing diagnosis. ---"
           kubectl get pods -n umbrella
-          
           for pod in $(kubectl get pods -n umbrella -o=jsonpath='{.items[*].metadata.name}'); do
             echo "--- Logs for pod: $pod ---"
             kubectl logs $pod -n umbrella || true
-            echo "--------------------------------------------------------"
           done
-          
           kubectl get events -n umbrella --sort-by='.metadata.creationTimestamp'
           helm history umbrella --namespace umbrella
-          
           exit 1
         fi
-        
-        echo "--- Installation successful. Starting cleanup... ---"
         helm uninstall umbrella --namespace umbrella
-
-    ## Skip upgrade for now until a working chart is released
-    #- name: Run helm upgrade
-    #  run: |
-    #    helm repo add bitnami https://charts.bitnami.com/bitnami
-    #    helm repo add tractusx-dev https://eclipse-tractusx.github.io/charts/dev
-    #    helm install [NAME] tractusx-dev/[CHART] --version ${{ github.event.inputs.upgrade_from || 'x.x.x' }}
-    #    helm dependency update charts/[CHART]
-    #    helm upgrade [NAME] charts/[CHART]
-
-  #kyverno:
-  #  runs-on: ubuntu-latest
-  #  needs: [list-changed]
-  #  if: ${{ github.event_name != 'pull_request' || needs.list-changed.outputs.changed == 'true' }}
-  #  steps:
-  #  - name: Checkout
-  #    uses: actions/checkout@v4
-#
-  #  - name: Install Helm
-  #    uses: azure/setup-helm@v3
-  #    with:
-  #      version: ${{ github.event.inputs.helm_version || 'latest' }}
-  #      token: ${{ secrets.GITHUB_TOKEN }}
-#
-  #  - name: Download chart dependencies (recursive)
-  #    shell: bash
-  #    run: hack/helm-dependencies.bash
-#
-  #  - name: Create Helm template
-  #    run: |
-  #       helm template chart-template charts/umbrella > charts/umbrella-template.yaml
-#
-  #  - name: Install Kyverno CLI
-  #    uses: kyverno/action-install-cli@v0.2.0          
-#
-  #  - name: Test new resources against existing policies
-  #    run: kyverno apply .github/kyverno-policies/ -r charts/umbrella-template.yaml

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0  # Ensure full clone for pull request workflows
 


### PR DESCRIPTION
## Description

This PR "migrates" the used version (without any upgrade) for checkout action to SHA. NO upgrade is done.
The SHA values can be found [here](https://github.com/actions/checkout/releases)

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files